### PR TITLE
make sure barcode appears on printed ballot

### DIFF
--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -1741,7 +1741,7 @@ exports[`end to end: election can be uploaded, voter can vote and print 8`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  min-height: 11in;
+  min-height: 9.5in;
   margin-top: 2rem;
   padding: 2rem;
   background: white;

--- a/src/components/__snapshots__/Ballot.test.tsx.snap
+++ b/src/components/__snapshots__/Ballot.test.tsx.snap
@@ -1545,7 +1545,7 @@ exports[`can navigate all ballot pages 7`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  min-height: 11in;
+  min-height: 9.5in;
   margin-top: 2rem;
   padding: 2rem;
   background: white;

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -16,7 +16,7 @@ import BallotContext from '../contexts/ballotContext'
 const Ballot = styled.section`
   display: flex;
   flex-direction: column;
-  min-height: 11in;
+  min-height: 9.5in;
   margin-top: 2rem;
   padding: 2rem;
   background: white;

--- a/src/pages/__snapshots__/ReviewPage.test.tsx.snap
+++ b/src/pages/__snapshots__/ReviewPage.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`renders SummaryPage with votes 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  min-height: 11in;
+  min-height: 9.5in;
   margin-top: 2rem;
   padding: 2rem;
   background: white;


### PR DESCRIPTION

Picked `min-height` 10in to have barcode at the bottom but consider 0.5" margins top/bottom.