### PR TITLE
Fix typo: Clearn -> Clear

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -27,7 +27,7 @@ const SettingsPage = () => {
             <h1>Settings</h1>
             <p>Settings will be available here.</p>
             <h2>Clear Selections</h2>
-            <p>Clearn all selections and start over.</p>
+            <p>Clear all selections and start over.</p>
             <Button onClick={requestNewBallot}>Start Over</Button>
           </Prose>
         </MainChild>

--- a/src/pages/__snapshots__/SettingsPage.test.tsx.snap
+++ b/src/pages/__snapshots__/SettingsPage.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`renders SettingsPage 1`] = `
         Clear Selections
       </h2>
       <p>
-        Clearn all selections and start over.
+        Clear all selections and start over.
       </p>
       <button
         class="c3"


### PR DESCRIPTION
This fixes a typo on the settings page: Clearn -> Clear.