### PR TITLE
Always hide ChromeVox UI when printing.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -128,3 +128,10 @@ html {
     margin-right: 0;
   }
 }
+
+@media print {
+  html body .cvox_indicator_container {
+    /* Extra specificity/!important ensure this rule is followed. */
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Duh. Simple solutions are always better. 