### PR TITLE
XAC controls for accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-dropzone": "9.0.0",
+    "react-gamepad": "^1.0.3",
     "react-modal": "^3.8.1",
     "react-router-dom": "^5.0.0",
     "react-scripts": "2.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,19 @@
 import Mousetrap from 'mousetrap'
 import React from 'react'
+// @ts-ignore - @types/react-gamepad doesn't exist
+import Gamepad from 'react-gamepad'
 import { RouteComponentProps } from 'react-router-dom'
 import { BrowserRouter, Route } from 'react-router-dom'
 
 import GLOBALS from './config/globals'
 
-// Enable to view the event atrributes
-// document.addEventListener('keydown', event => {
-//   console.log('==============================')
-//   console.log('==============================')
-//   console.log('==============================')
-//   console.log('Event:', event)
-//   console.log('Keyboard Event object keys:', {
-//     charCode: event.charCode,
-//     code: event.code,
-//     key: event.key,
-//     keyCode: event.keyCode,
-//     metaKey: event.metaKey,
-//   })
-//   console.log('==============================')
-//   console.log('==============================')
-//   console.log('==============================')
-// })
-
 import 'normalize.css'
 import './App.css'
+
+import {
+  handleGamepadButtonDown,
+  handleGamepadKeyboardEvent,
+} from './lib/gamepad'
 
 import {
   Election,
@@ -88,12 +77,14 @@ class App extends React.Component<RouteComponentProps, State> {
       })
     }
     Mousetrap.bind(removeElectionShortcuts, this.reset)
+    document.addEventListener('keydown', handleGamepadKeyboardEvent)
     document.documentElement.setAttribute('data-useragent', navigator.userAgent)
     this.setDocumentFontSize()
   }
 
   public componentWillUnount = /* istanbul ignore next */ () => {
     Mousetrap.unbind(removeElectionShortcuts)
+    document.removeEventListener('keydown', handleGamepadKeyboardEvent)
   }
 
   public getElection = (): OptionalElection => {
@@ -169,19 +160,21 @@ class App extends React.Component<RouteComponentProps, State> {
       return <UploadConfig setElection={this.setElection} />
     } else {
       return (
-        <BallotContext.Provider
-          value={{
-            election,
-            resetBallot: this.resetBallot,
-            setBallotKey: this.setBallotKey,
-            setUserSettings: this.setUserSettings,
-            updateVote: this.updateVote,
-            userSettings: this.state.userSettings,
-            votes: this.state.votes,
-          }}
-        >
-          <Ballot />
-        </BallotContext.Provider>
+        <Gamepad onButtonDown={handleGamepadButtonDown}>
+          <BallotContext.Provider
+            value={{
+              election,
+              resetBallot: this.resetBallot,
+              setBallotKey: this.setBallotKey,
+              setUserSettings: this.setUserSettings,
+              updateVote: this.updateVote,
+              userSettings: this.state.userSettings,
+              votes: this.state.votes,
+            }}
+          >
+            <Ballot />
+          </BallotContext.Provider>
+        </Gamepad>
       )
     }
   }

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -1202,12 +1202,14 @@ button.c7 {
   >
     <button
       class="c1"
+      id="next"
       type="button"
     >
       Next
     </button>
     <button
       class="c1"
+      id="previous"
       type="button"
     >
       Previous
@@ -1325,21 +1327,274 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
   class="sc-brqgnP dZCvJT"
   tabindex="-1"
 >
-  <main
-    class="sc-gqjmRU ktPUDL"
+  .c2 {
+  line-height: 1.2;
+  max-width: 66ch;
+}
+
+.c2 h1 {
+  line-height: 1.1;
+  margin: 2rem 0 1rem;
+}
+
+.c2 h2 {
+  margin: 1.5rem 0 1rem;
+}
+
+.c2 h3,
+.c2 p {
+  margin: 1rem 0;
+}
+
+.c2 h1 + h2 {
+  margin-top: -0.75rem;
+}
+
+.c2 h1 + p,
+.c2 h2 + p,
+.c2 h3 + p {
+  margin-top: -0.75rem;
+}
+
+.c2 :first-child {
+  margin-top: 0;
+}
+
+.c2 :last-child {
+  margin-bottom: 0;
+}
+
+.c3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.c0 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 {
+  width: 100%;
+  max-width: 35rem;
+  margin: 0px auto;
+  padding: 1rem 0.75rem 0.5rem;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  position: relative;
+  overflow: auto;
+}
+
+.c5 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: auto;
+}
+
+.c5:before {
+  content: '';
+  z-index: 1;
+  -webkit-transition: opacity 0.25s ease;
+  transition: opacity 0.25s ease;
+  height: 5px;
+  width: 100%;
+  position: fixed;
+  opacity: 0;
+  background: linear-gradient( to bottom, rgb(177,186,190) 0%, transparent 100% );
+}
+
+.c6 {
+  display: grid;
+  grid-auto-rows: minmax(auto,1fr);
+  grid-gap: 0.75rem;
+  width: 100%;
+  max-width: 35rem;
+  margin: 0 auto;
+  padding: 0.5rem 0.5rem 2rem;
+}
+
+.c9 {
+  cursor: pointer;
+  position: relative;
+  display: grid;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.125rem;
+  background: white;
+  box-shadow: 0 0.125rem 0.125rem 0 rgba(0,0,0,0.14), 0 0.1875rem 0.0625rem -0.125rem rgba(0,0,0,0.12), 0 0.0625rem 0.3125rem 0 rgba(0,0,0,0.2);
+  -webkit-transition: background 0.25s,color 0.25s;
+  transition: background 0.25s,color 0.25s;
+}
+
+button.c9 {
+  text-align: left;
+}
+
+.c9:focus-within {
+  outline: -webkit-focus-ring-color auto 5px;
+}
+
+.c9:before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: white;
+  border-right: 1px solid;
+  border-color: lightgrey;
+  width: 3rem;
+  text-align: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 2rem;
+  border-radius: 0.125rem 0 0 0.125rem;
+  color: #028099;
+}
+
+.c9 > div {
+  word-break: break-word;
+  padding: 0.5rem 0.5rem 0.5rem 4rem;
+}
+
+.c7 {
+  cursor: pointer;
+  position: relative;
+  display: grid;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.125rem;
+  background: #028099;
+  color: white;
+  box-shadow: 0 0.125rem 0.125rem 0 rgba(0,0,0,0.14), 0 0.1875rem 0.0625rem -0.125rem rgba(0,0,0,0.12), 0 0.0625rem 0.3125rem 0 rgba(0,0,0,0.2);
+  -webkit-transition: background 0.25s,color 0.25s;
+  transition: background 0.25s,color 0.25s;
+}
+
+button.c7 {
+  text-align: left;
+}
+
+.c7:focus-within {
+  outline: -webkit-focus-ring-color auto 5px;
+}
+
+.c7:before {
+  content: '✓';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: white;
+  border-right: 1px solid;
+  border-color: #028099;
+  width: 3rem;
+  text-align: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 2rem;
+  border-radius: 0.125rem 0 0 0.125rem;
+  color: #028099;
+}
+
+.c7 > div {
+  word-break: break-word;
+  padding: 0.5rem 0.5rem 0.5rem 4rem;
+}
+
+.c8 {
+  margin-right: 0.5rem;
+}
+
+@media (min-width:480px) {
+  .c2 {
+    line-height: 1.3;
+  }
+}
+
+@media (min-width:640px) {
+  .c1 {
+    padding: 1rem 1.5rem 0.5rem;
+    padding-left: 5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c6 {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+}
+
+@media (min-width:480px) {
+  .c9 > div {
+    padding: 1rem 1rem 1rem inherit;
+  }
+}
+
+@media (min-width:480px) {
+  .c7 > div {
+    padding: 1rem 1rem 1rem inherit;
+  }
+}
+
+<main
+    class="c0"
   >
     <div
-      class="sc-VigVT lbUcAU"
+      class="c1"
       id="contest-header"
     >
       <div
-        class="sc-htpNat fSsZTl"
+        class="c2"
       >
         <h1
           aria-label="Federal, President and Vice-President of the United States."
         >
           <div
-            class="sc-gZMcBi jfQfOL"
+            class="c3"
           >
             Federal
           </div>
@@ -1359,29 +1614,29 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
       </div>
     </div>
     <div
-      class="sc-jTzLTM gNXRLH"
+      class="c4"
     >
       <div
-        class="sc-jzJRlG kXRdgz"
+        class="c5"
       >
         <div
           aria-labelledby="contest-header"
-          class="sc-cSHVUG fZpRev"
+          class="c6"
           role="group"
         >
           <label
-            class="sc-kAzzGY buGPUT"
+            class="c7"
             for="barchi-hallaren"
           >
             <input
-              class="visually-hidden sc-chPdSV ebSUow"
+              class="visually-hidden c8"
               id="barchi-hallaren"
               name="Joseph Barchi and Joseph Hallaren"
               type="checkbox"
               value="barchi-hallaren"
             />
             <div
-              class="sc-htpNat fSsZTl"
+              class="c2"
             >
               <p
                 aria-label="Joseph Barchi and Joseph Hallaren, Federalist."
@@ -1395,11 +1650,11 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
             </div>
           </label>
           <label
-            class="sc-kAzzGY wDcca"
+            class="c9"
             for="cramer-vuocolo"
           >
             <input
-              class="visually-hidden sc-chPdSV ebSUow"
+              class="visually-hidden c8"
               disabled=""
               id="cramer-vuocolo"
               name="Adam Cramer and Greg Vuocolo"
@@ -1407,7 +1662,7 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
               value="cramer-vuocolo"
             />
             <div
-              class="sc-htpNat fSsZTl"
+              class="c2"
             >
               <p
                 aria-label="Adam Cramer and Greg Vuocolo, People's."
@@ -1421,11 +1676,11 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
             </div>
           </label>
           <label
-            class="sc-kAzzGY wDcca"
+            class="c9"
             for="court-blumhardt"
           >
             <input
-              class="visually-hidden sc-chPdSV ebSUow"
+              class="visually-hidden c8"
               disabled=""
               id="court-blumhardt"
               name="Daniel Court and Amy Blumhardt"
@@ -1433,7 +1688,7 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
               value="court-blumhardt"
             />
             <div
-              class="sc-htpNat fSsZTl"
+              class="c2"
             >
               <p
                 aria-label="Daniel Court and Amy Blumhardt, Liberty."
@@ -1447,11 +1702,11 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
             </div>
           </label>
           <label
-            class="sc-kAzzGY wDcca"
+            class="c9"
             for="boone-lian"
           >
             <input
-              class="visually-hidden sc-chPdSV ebSUow"
+              class="visually-hidden c8"
               disabled=""
               id="boone-lian"
               name="Alvin Boone and James Lian"
@@ -1459,7 +1714,7 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
               value="boone-lian"
             />
             <div
-              class="sc-htpNat fSsZTl"
+              class="c2"
             >
               <p
                 aria-label="Alvin Boone and James Lian, Constitution."
@@ -1473,11 +1728,11 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
             </div>
           </label>
           <label
-            class="sc-kAzzGY wDcca"
+            class="c9"
             for="hildebrand-garritty"
           >
             <input
-              class="visually-hidden sc-chPdSV ebSUow"
+              class="visually-hidden c8"
               disabled=""
               id="hildebrand-garritty"
               name="Ashley Hildebrand-MacDougall and James Garritty"
@@ -1485,7 +1740,7 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
               value="hildebrand-garritty"
             />
             <div
-              class="sc-htpNat fSsZTl"
+              class="c2"
             >
               <p
                 aria-label="Ashley Hildebrand-MacDougall and James Garritty, Whig."
@@ -1499,11 +1754,11 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
             </div>
           </label>
           <label
-            class="sc-kAzzGY wDcca"
+            class="c9"
             for="patterson-lariviere"
           >
             <input
-              class="visually-hidden sc-chPdSV ebSUow"
+              class="visually-hidden c8"
               disabled=""
               id="patterson-lariviere"
               name="Martin Patterson and Clay Lariviere"
@@ -1511,7 +1766,7 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
               value="patterson-lariviere"
             />
             <div
-              class="sc-htpNat fSsZTl"
+              class="c2"
             >
               <p
                 aria-label="Martin Patterson and Clay Lariviere, Labor."
@@ -1533,12 +1788,26 @@ exports[`end to end: election can be uploaded, voter can vote and print 5`] = `
   >
     <button
       class="sc-EHOje bOrYaz"
+      id="next"
       type="button"
     >
       Next
     </button>
-    <button
-      class="sc-EHOje egcjKC"
+    .c0 {
+  box-sizing: border-box;
+  cursor: pointer;
+  background: lightgrey;
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.4rem 0.7rem;
+  color: black;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+<button
+      class="c0"
+      id="previous"
       type="button"
     >
       Previous

--- a/src/lib/gamepad.ts
+++ b/src/lib/gamepad.ts
@@ -1,0 +1,86 @@
+import mod from '../utils/mod'
+
+const getFocusableElements = (): HTMLElement[] =>
+  Array.from(document.querySelectorAll('button:not([tabindex="-1"]), input'))
+
+const getActiveElement = () => document.activeElement! as HTMLInputElement
+
+function handleArrowUp() {
+  const focusable = getFocusableElements()
+  const currentIndex = focusable.indexOf(getActiveElement())
+  if (currentIndex > -1) {
+    focusable[mod(currentIndex - 1, focusable.length)].focus()
+  } else {
+    focusable[focusable.length - 1].focus()
+  }
+}
+
+function handleArrowDown() {
+  const focusable = getFocusableElements()
+  const currentIndex = focusable.indexOf(getActiveElement())
+  focusable[mod(currentIndex + 1, focusable.length)].focus()
+}
+
+function handleArrowLeft() {
+  const prevButton = document.getElementById('previous') as HTMLButtonElement
+  if (prevButton) {
+    prevButton.click()
+  }
+}
+
+function handleArrowRight() {
+  const nextButton = document.getElementById('next') as HTMLButtonElement
+  if (nextButton) {
+    nextButton.click()
+  }
+}
+
+function handleClick() {
+  getActiveElement().click()
+}
+
+export function handleGamepadButtonDown(buttonName: string) {
+  switch (buttonName) {
+    case 'DPadUp':
+      handleArrowUp()
+      break
+    case 'A':
+    case 'DPadDown':
+      handleArrowDown()
+      break
+    case 'DPadLeft':
+      handleArrowLeft()
+      break
+    case 'DPadRight':
+      handleArrowRight()
+      break
+    case 'B':
+      handleClick()
+      break
+  }
+}
+
+// Add Cypress tests if this solution will become permanent
+// https://docs.cypress.io/api/commands/type.html
+export /* istanbul ignore next */ function handleGamepadKeyboardEvent(
+  event: KeyboardEvent
+) {
+  switch (event.key) {
+    case 'ArrowUp':
+      handleArrowUp()
+      break
+    case '[':
+    case 'ArrowDown':
+      handleArrowDown()
+      break
+    case 'ArrowLeft':
+      handleArrowLeft()
+      break
+    case 'ArrowRight':
+      handleArrowRight()
+      break
+    case ']':
+      handleClick()
+      break
+  }
+}

--- a/src/pages/ContestPage.tsx
+++ b/src/pages/ContestPage.tsx
@@ -56,6 +56,7 @@ const ContestPage = (props: Props) => {
       <ButtonBar>
         {nextContest ? (
           <LinkButton
+            id="next"
             key="next"
             primary={!!vote}
             to={`/contests/${nextContest && nextContest.id}`}
@@ -63,19 +64,20 @@ const ContestPage = (props: Props) => {
             Next
           </LinkButton>
         ) : (
-          <LinkButton primary={!!vote} to="/review" key="review">
+          <LinkButton primary={!!vote} to="/review" key="review" id="next">
             Review
           </LinkButton>
         )}
         {prevContest ? (
           <LinkButton
+            id="previous"
             to={`/contests/${prevContest && prevContest.id}`}
             key="previous"
           >
             Previous
           </LinkButton>
         ) : (
-          <LinkButton key="backtostart" to="/start">
+          <LinkButton key="backtostart" to="/start" id="previous">
             Previous
           </LinkButton>
         )}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -232,7 +232,9 @@ class SummaryPage extends React.Component<RouteComponentProps, State> {
           <Button primary onClick={this.showConfirm}>
             Print Ballot
           </Button>
-          <LinkButton goBack>Back</LinkButton>
+          <LinkButton goBack id="previous">
+            Back
+          </LinkButton>
         </ButtonBar>
         <Modal
           isOpen={this.state.showConfirmModal}

--- a/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -209,12 +209,14 @@ exports[`displays accessible error if no id match 1`] = `
   >
     <button
       class="c2"
+      id="next"
       type="button"
     >
       Next
     </button>
     <button
       class="c2"
+      id="previous"
       type="button"
     >
       Previous
@@ -780,12 +782,14 @@ button.c7 {
   >
     <button
       class="c10"
+      id="next"
       type="button"
     >
       Next
     </button>
     <button
       class="c10"
+      id="previous"
       type="button"
     >
       Previous
@@ -1339,12 +1343,14 @@ button.c7 {
   >
     <button
       class="c10"
+      id="next"
       type="button"
     >
       Next
     </button>
     <button
       class="c10"
+      id="previous"
       type="button"
     >
       Previous
@@ -1591,12 +1597,14 @@ exports[`renders error if no id match 1`] = `
   >
     <button
       class="c2"
+      id="next"
       type="button"
     >
       Next
     </button>
     <button
       class="c2"
+      id="previous"
       type="button"
     >
       Previous

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -1,0 +1,2 @@
+const mod = (x: number, n: number) => ((x % n) + n) % n
+export default mod

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,12 +9563,17 @@ react-error-overlay@^5.1.4:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.4.tgz#88dfb88857c18ceb3b9f95076f850d7121776991"
   integrity sha512-fp+U98OMZcnduQ+NSEiQa4s/XMsbp+5KlydmkbESOw4P69iWZ68ZMFM5a2BuE0FgqPBKApJyRuYHR95jM8lAmg==
 
-react-is@^16.3.2, react-is@^16.6.0, react-is@^16.8.1, react-is@^16.8.4:
+react-gamepad@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-gamepad/-/react-gamepad-1.0.3.tgz#c50606992c34589bd19f8bb09914084f5c92f4a2"
+  integrity sha512-gMwITmfoHtCaMFpDaEshcjeibHAgynXD28NnS2pa+dG+stwNoN66YDVizN7GfyIrYiW5Ft1ubRxs6/2xW9sRhQ==
+
+react-is@^16.3.2, react-is@^16.8.4:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
-react-is@^16.7.0:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==


### PR DESCRIPTION
set up actions for keyboard keys that are meant to simulate XAC keys for testing.
* arrow keys as expected: ⬅️ ➡️ ⬆️ ⬇️
* `[` and `]` for B and A keys respectively.

This is implemented by doing some DOM navigation and clicking. There's an argument that this isn't the most modular React way to do this, but I'm not even sure what a correct React way to do this would be, and I suspect it would be a good bit gnarlier.