### PR TITLE
Fix review page for numeric contest ids

### DIFF
--- a/cypress/tests/scroll-to-contest.js
+++ b/cypress/tests/scroll-to-contest.js
@@ -13,9 +13,9 @@ describe('Review Page', () => {
     cy.wrap(clickThoughPages).each(() => {
       cy.contains('Next').click()
     })
-    cy.get('#county-commissioners').click()
+    cy.get('#contest-county-commissioners').click()
     cy.contains('Review Ballot').click()
-    cy.get('#county-commissioners').should('be.visible')
-    cy.focused().should('have.attr', 'id', 'county-commissioners')
+    cy.get('#contest-county-commissioners').should('be.visible')
+    cy.focused().should('have.attr', 'id', 'contest-county-commissioners')
   })
 })

--- a/src/__snapshots__/AppEndToEnd.test.tsx.snap
+++ b/src/__snapshots__/AppEndToEnd.test.tsx.snap
@@ -1553,7 +1553,7 @@ button.c10 {
           <input
             class="visually-hidden c11"
             id="yes"
-            name="measure-102"
+            name="102"
             type="checkbox"
             value="yes"
           />
@@ -1574,7 +1574,7 @@ button.c10 {
           <input
             class="visually-hidden c11"
             id="no"
-            name="measure-102"
+            name="102"
             type="checkbox"
             value="no"
           />
@@ -1706,7 +1706,7 @@ exports[`basic end-to-end flow 5`] = `
           <input
             class="visually-hidden sc-brqgnP fZhdBB"
             id="yes"
-            name="measure-102"
+            name="102"
             type="checkbox"
             value="yes"
           />
@@ -1727,7 +1727,7 @@ exports[`basic end-to-end flow 5`] = `
           <input
             class="visually-hidden sc-brqgnP fZhdBB"
             id="no"
-            name="measure-102"
+            name="102"
             type="checkbox"
             value="no"
           />
@@ -2477,7 +2477,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/0#review"
-            id="president"
+            id="contest-president"
             tabindex="0"
           >
             <div
@@ -2514,7 +2514,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/1#review"
-            id="senator"
+            id="contest-senator"
             tabindex="0"
           >
             <div
@@ -2547,7 +2547,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/2#review"
-            id="representative-district-6"
+            id="contest-representative-district-6"
             tabindex="0"
           >
             <div
@@ -2580,7 +2580,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/3#review"
-            id="governor"
+            id="contest-governor"
             tabindex="0"
           >
             <div
@@ -2613,7 +2613,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/4#review"
-            id="lieutenant-governor"
+            id="contest-lieutenant-governor"
             tabindex="0"
           >
             <div
@@ -2646,7 +2646,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/5#review"
-            id="secretary-of-state"
+            id="contest-secretary-of-state"
             tabindex="0"
           >
             <div
@@ -2679,7 +2679,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/6#review"
-            id="state-senator-district-31"
+            id="contest-state-senator-district-31"
             tabindex="0"
           >
             <div
@@ -2712,7 +2712,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/7#review"
-            id="state-assembly-district-54"
+            id="contest-state-assembly-district-54"
             tabindex="0"
           >
             <div
@@ -2745,7 +2745,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/8#review"
-            id="county-commissioners"
+            id="contest-county-commissioners"
             tabindex="0"
           >
             <div
@@ -2778,7 +2778,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/9#review"
-            id="county-registrar-of-wills"
+            id="contest-county-registrar-of-wills"
             tabindex="0"
           >
             <div
@@ -2811,7 +2811,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/10#review"
-            id="city-mayor"
+            id="contest-city-mayor"
             tabindex="0"
           >
             <div
@@ -2844,7 +2844,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/11#review"
-            id="city-council"
+            id="contest-city-council"
             tabindex="0"
           >
             <div
@@ -2877,7 +2877,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/12#review"
-            id="judicial-robert-demergue"
+            id="contest-judicial-robert-demergue"
             tabindex="0"
           >
             <div
@@ -2910,7 +2910,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/13#review"
-            id="judicial-elmer-hull"
+            id="contest-judicial-elmer-hull"
             tabindex="0"
           >
             <div
@@ -2943,7 +2943,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/14#review"
-            id="question-a"
+            id="contest-question-a"
             tabindex="0"
           >
             <div
@@ -2976,7 +2976,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/15#review"
-            id="question-b"
+            id="contest-question-b"
             tabindex="0"
           >
             <div
@@ -3009,7 +3009,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/16#review"
-            id="question-c"
+            id="contest-question-c"
             tabindex="0"
           >
             <div
@@ -3042,7 +3042,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/17#review"
-            id="proposition-1"
+            id="contest-proposition-1"
             tabindex="0"
           >
             <div
@@ -3075,7 +3075,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/18#review"
-            id="measure-101"
+            id="contest-measure-101"
             tabindex="0"
           >
             <div
@@ -3108,7 +3108,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/19#review"
-            id="measure-102"
+            id="contest-102"
             tabindex="0"
           >
             <div
@@ -5071,7 +5071,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/0#review"
-            id="president"
+            id="contest-president"
             tabindex="0"
           >
             <div
@@ -5108,7 +5108,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/1#review"
-            id="senator"
+            id="contest-senator"
             tabindex="0"
           >
             <div
@@ -5141,7 +5141,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/2#review"
-            id="representative-district-6"
+            id="contest-representative-district-6"
             tabindex="0"
           >
             <div
@@ -5174,7 +5174,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/3#review"
-            id="governor"
+            id="contest-governor"
             tabindex="0"
           >
             <div
@@ -5207,7 +5207,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/4#review"
-            id="lieutenant-governor"
+            id="contest-lieutenant-governor"
             tabindex="0"
           >
             <div
@@ -5240,7 +5240,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/5#review"
-            id="secretary-of-state"
+            id="contest-secretary-of-state"
             tabindex="0"
           >
             <div
@@ -5273,7 +5273,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/6#review"
-            id="state-senator-district-31"
+            id="contest-state-senator-district-31"
             tabindex="0"
           >
             <div
@@ -5306,7 +5306,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/7#review"
-            id="state-assembly-district-54"
+            id="contest-state-assembly-district-54"
             tabindex="0"
           >
             <div
@@ -5339,7 +5339,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/8#review"
-            id="county-commissioners"
+            id="contest-county-commissioners"
             tabindex="0"
           >
             <div
@@ -5396,7 +5396,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/9#review"
-            id="county-registrar-of-wills"
+            id="contest-county-registrar-of-wills"
             tabindex="0"
           >
             <div
@@ -5429,7 +5429,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/10#review"
-            id="city-mayor"
+            id="contest-city-mayor"
             tabindex="0"
           >
             <div
@@ -5462,7 +5462,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/11#review"
-            id="city-council"
+            id="contest-city-council"
             tabindex="0"
           >
             <div
@@ -5495,7 +5495,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/12#review"
-            id="judicial-robert-demergue"
+            id="contest-judicial-robert-demergue"
             tabindex="0"
           >
             <div
@@ -5528,7 +5528,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/13#review"
-            id="judicial-elmer-hull"
+            id="contest-judicial-elmer-hull"
             tabindex="0"
           >
             <div
@@ -5561,7 +5561,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/14#review"
-            id="question-a"
+            id="contest-question-a"
             tabindex="0"
           >
             <div
@@ -5594,7 +5594,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/15#review"
-            id="question-b"
+            id="contest-question-b"
             tabindex="0"
           >
             <div
@@ -5627,7 +5627,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/16#review"
-            id="question-c"
+            id="contest-question-c"
             tabindex="0"
           >
             <div
@@ -5660,7 +5660,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/17#review"
-            id="proposition-1"
+            id="contest-proposition-1"
             tabindex="0"
           >
             <div
@@ -5693,7 +5693,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/18#review"
-            id="measure-101"
+            id="contest-measure-101"
             tabindex="0"
           >
             <div
@@ -5726,7 +5726,7 @@ button.c7 {
           <a
             class="c7"
             href="/contests/19#review"
-            id="measure-102"
+            id="contest-102"
             tabindex="0"
           >
             <div

--- a/src/data/electionSample.json
+++ b/src/data/electionSample.json
@@ -627,7 +627,7 @@
       "description": "To upgrade educational facilities at Diablo Valley, and Franklin, Colleges, and the San Brentwood center, and help prepare students for jobs and college transfer by modernizing classrooms and labs, building facilities for health, medical, science, and technology training, and implementing infrastructure improvements, shall the Franklin Community College District issue $450 million of bonds at legal interest rates with independent oversight, audits, and all funds spent on local sites?"
     },
     {
-      "id": "measure-102",
+      "id": "102",
       "districtId": "district-1",
       "type": "yesno",
       "section": "Franklin County",

--- a/src/pages/ContestPage.tsx
+++ b/src/pages/ContestPage.tsx
@@ -75,7 +75,7 @@ const ContestPage = (props: Props) => {
           <React.Fragment>
             <LinkButton
               primary={isVoteComplete}
-              to={`/review#${contest.id}`}
+              to={`/review#contest-${contest.id}`}
               id="next"
             >
               Review Ballot

--- a/src/pages/ReviewPage.test.tsx
+++ b/src/pages/ReviewPage.test.tsx
@@ -14,6 +14,8 @@ const contest1candidate0 = contest1.candidates[0]
 
 import ReviewPage from './ReviewPage'
 
+const idValueStartsWithNumberRegex = new RegExp('id="[0-9]')
+
 it(`renders ReviewPage without votes`, () => {
   const { container } = render(
     <Route path="/review" component={ReviewPage} />,
@@ -35,5 +37,8 @@ it(`renders ReviewPage with votes`, () => {
       },
     }
   )
+
+  // DOM node IDs cannot start with a number. Browsers will error out.
+  expect(idValueStartsWithNumberRegex.test(container.outerHTML)).toBeFalsy()
   expect(container.firstChild).toMatchSnapshot()
 })

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -313,7 +313,7 @@ class ReviewPage extends React.Component<RouteComponentProps, State> {
               <ScrollableContentWrapper isScrollable={isScrollable}>
                 {(contests as Contests).map((contest, i) => (
                   <Contest
-                    id={contest.id}
+                    id={`contest-${contest.id}`}
                     key={contest.id}
                     tabIndex={0}
                     to={`/contests/${i}#review`}

--- a/src/pages/__snapshots__/ReviewPage.test.tsx.snap
+++ b/src/pages/__snapshots__/ReviewPage.test.tsx.snap
@@ -365,7 +365,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/0#review"
-          id="president"
+          id="contest-president"
           tabindex="0"
         >
           <div
@@ -402,7 +402,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/1#review"
-          id="senator"
+          id="contest-senator"
           tabindex="0"
         >
           <div
@@ -439,7 +439,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/2#review"
-          id="representative-district-6"
+          id="contest-representative-district-6"
           tabindex="0"
         >
           <div
@@ -472,7 +472,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/3#review"
-          id="governor"
+          id="contest-governor"
           tabindex="0"
         >
           <div
@@ -505,7 +505,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/4#review"
-          id="lieutenant-governor"
+          id="contest-lieutenant-governor"
           tabindex="0"
         >
           <div
@@ -538,7 +538,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/5#review"
-          id="secretary-of-state"
+          id="contest-secretary-of-state"
           tabindex="0"
         >
           <div
@@ -571,7 +571,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/6#review"
-          id="state-senator-district-31"
+          id="contest-state-senator-district-31"
           tabindex="0"
         >
           <div
@@ -604,7 +604,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/7#review"
-          id="state-assembly-district-54"
+          id="contest-state-assembly-district-54"
           tabindex="0"
         >
           <div
@@ -637,7 +637,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/8#review"
-          id="county-commissioners"
+          id="contest-county-commissioners"
           tabindex="0"
         >
           <div
@@ -670,7 +670,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/9#review"
-          id="county-registrar-of-wills"
+          id="contest-county-registrar-of-wills"
           tabindex="0"
         >
           <div
@@ -703,7 +703,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/10#review"
-          id="city-mayor"
+          id="contest-city-mayor"
           tabindex="0"
         >
           <div
@@ -736,7 +736,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/11#review"
-          id="city-council"
+          id="contest-city-council"
           tabindex="0"
         >
           <div
@@ -769,7 +769,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/12#review"
-          id="judicial-robert-demergue"
+          id="contest-judicial-robert-demergue"
           tabindex="0"
         >
           <div
@@ -802,7 +802,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/13#review"
-          id="judicial-elmer-hull"
+          id="contest-judicial-elmer-hull"
           tabindex="0"
         >
           <div
@@ -835,7 +835,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/14#review"
-          id="question-a"
+          id="contest-question-a"
           tabindex="0"
         >
           <div
@@ -868,7 +868,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/15#review"
-          id="question-b"
+          id="contest-question-b"
           tabindex="0"
         >
           <div
@@ -901,7 +901,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/16#review"
-          id="question-c"
+          id="contest-question-c"
           tabindex="0"
         >
           <div
@@ -934,7 +934,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/17#review"
-          id="proposition-1"
+          id="contest-proposition-1"
           tabindex="0"
         >
           <div
@@ -967,7 +967,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/18#review"
-          id="measure-101"
+          id="contest-measure-101"
           tabindex="0"
         >
           <div
@@ -1000,7 +1000,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/19#review"
-          id="measure-102"
+          id="contest-102"
           tabindex="0"
         >
           <div
@@ -1394,7 +1394,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/0#review"
-          id="president"
+          id="contest-president"
           tabindex="0"
         >
           <div
@@ -1427,7 +1427,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/1#review"
-          id="senator"
+          id="contest-senator"
           tabindex="0"
         >
           <div
@@ -1460,7 +1460,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/2#review"
-          id="representative-district-6"
+          id="contest-representative-district-6"
           tabindex="0"
         >
           <div
@@ -1493,7 +1493,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/3#review"
-          id="governor"
+          id="contest-governor"
           tabindex="0"
         >
           <div
@@ -1526,7 +1526,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/4#review"
-          id="lieutenant-governor"
+          id="contest-lieutenant-governor"
           tabindex="0"
         >
           <div
@@ -1559,7 +1559,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/5#review"
-          id="secretary-of-state"
+          id="contest-secretary-of-state"
           tabindex="0"
         >
           <div
@@ -1592,7 +1592,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/6#review"
-          id="state-senator-district-31"
+          id="contest-state-senator-district-31"
           tabindex="0"
         >
           <div
@@ -1625,7 +1625,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/7#review"
-          id="state-assembly-district-54"
+          id="contest-state-assembly-district-54"
           tabindex="0"
         >
           <div
@@ -1658,7 +1658,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/8#review"
-          id="county-commissioners"
+          id="contest-county-commissioners"
           tabindex="0"
         >
           <div
@@ -1691,7 +1691,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/9#review"
-          id="county-registrar-of-wills"
+          id="contest-county-registrar-of-wills"
           tabindex="0"
         >
           <div
@@ -1724,7 +1724,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/10#review"
-          id="city-mayor"
+          id="contest-city-mayor"
           tabindex="0"
         >
           <div
@@ -1757,7 +1757,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/11#review"
-          id="city-council"
+          id="contest-city-council"
           tabindex="0"
         >
           <div
@@ -1790,7 +1790,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/12#review"
-          id="judicial-robert-demergue"
+          id="contest-judicial-robert-demergue"
           tabindex="0"
         >
           <div
@@ -1823,7 +1823,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/13#review"
-          id="judicial-elmer-hull"
+          id="contest-judicial-elmer-hull"
           tabindex="0"
         >
           <div
@@ -1856,7 +1856,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/14#review"
-          id="question-a"
+          id="contest-question-a"
           tabindex="0"
         >
           <div
@@ -1889,7 +1889,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/15#review"
-          id="question-b"
+          id="contest-question-b"
           tabindex="0"
         >
           <div
@@ -1922,7 +1922,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/16#review"
-          id="question-c"
+          id="contest-question-c"
           tabindex="0"
         >
           <div
@@ -1955,7 +1955,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/17#review"
-          id="proposition-1"
+          id="contest-proposition-1"
           tabindex="0"
         >
           <div
@@ -1988,7 +1988,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/18#review"
-          id="measure-101"
+          id="contest-measure-101"
           tabindex="0"
         >
           <div
@@ -2021,7 +2021,7 @@ button.c7 {
         <a
           class="c7"
           href="/contests/19#review"
-          id="measure-102"
+          id="contest-102"
           tabindex="0"
         >
           <div


### PR DESCRIPTION
This was breaking for a different sample file where `contest.id` was only numeric, which makes for a disallowed DOM node `id`. Added a prefix and a test to make sure we don't later regress.