### PR TITLE
added proxying for development with yarn start and the backend server

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/react-router-dom": "^4.3.3",
     "@types/styled-components": "^4.1.15",
     "history": "^4.9.0",
+    "http-proxy-middleware": "^0.19.1",
     "lodash.camelcase": "^4.3.0",
     "mousetrap": "^1.6.3",
     "normalize.css": "^8.0.1",

--- a/server/Makefile
+++ b/server/Makefile
@@ -6,11 +6,11 @@ install-smartcard:
 	apt install libusb-1.0-0-dev libpcsclite-dev pcscd pcsc-tools swig
 
 install-dependencies:
-	pip3 install pipenv
-	pipenv install
+	python3 -m pip install pipenv
+	python3 -m pipenv install
 
 install-dev-dependencies:
-	pipenv install --dev
+	python3 -m pipenv install --dev
 
 test:
 	python -m pytest
@@ -19,4 +19,4 @@ coverage:
 	python -m pytest --cov=bmdserver --cov-report term-missing --cov-fail-under=100 tests/
 
 run:
-	FLASK_APP=bmdserver.core python -m flask run --port 3000
+	FLASK_APP=bmdserver.core python -m flask run --port 3001

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,13 @@
+// This file sets up React's proxy in development mode.
+//
+// Currently, non-native Node languages (e.g. typescript) are explicitly not supported:
+// https://facebook.github.io/create-react-app/docs/proxying-api-requests-in-development#configuring-the-proxy-manually
+//
+/* eslint-disable */
+/* istanbul ignore file */
+
+const proxy = require('http-proxy-middleware')
+
+module.exports = function(app) {
+  app.use(proxy('/card', { target: 'http://localhost:3001/' }))
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "strict": true,
     "target": "es5"
   },
+  "exclude": ["src/setupProxy.js"],
   "include": ["src"]
 }


### PR DESCRIPTION

Using `package.json` proxying, development is now way easier with both front-end and backend at the same time.