### PR TITLE
enter key also selects

### DIFF
--- a/src/lib/gamepad.ts
+++ b/src/lib/gamepad.ts
@@ -92,6 +92,7 @@ export /* istanbul ignore next - triggering keystrokes issue - https://github.co
       handleArrowRight()
       break
     case ']':
+    case 'Enter':
       handleClick()
       break
     // no default


### PR DESCRIPTION
Some keypad controllers use "Enter" as the selection key.