### PR TITLE
add timeout to resetballot cause recursion

### DIFF
--- a/src/AppEndToEnd.test.tsx
+++ b/src/AppEndToEnd.test.tsx
@@ -208,6 +208,7 @@ it(`basic end-to-end flow`, async () => {
   })
 
   // Review and Cast Instructions
+  await sleep(100)
   getByText('Verify and Cast Your Ballot')
 
   // ===========================================================================

--- a/src/AppEndToEnd.test.tsx
+++ b/src/AppEndToEnd.test.tsx
@@ -208,6 +208,7 @@ it(`basic end-to-end flow`, async () => {
   })
 
   // Review and Cast Instructions
+  // wait a little bit because the page transition is behind a setTimeout
   await sleep(100)
   getByText('Verify and Cast Your Ballot')
 

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -163,7 +163,9 @@ class SummaryPage extends React.Component<RouteComponentProps, State> {
     window.removeEventListener('afterprint', this.resetBallot)
   }
   public resetBallot = () => {
-    this.context.resetBallot('/cast')
+    window.setTimeout(() => {
+      this.context.resetBallot('/cast')
+    }, 0)
   }
   public hideConfirm = () => {
     this.setState({ showConfirmModal: false })

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -163,6 +163,7 @@ class SummaryPage extends React.Component<RouteComponentProps, State> {
     window.removeEventListener('afterprint', this.resetBallot)
   }
   public resetBallot = () => {
+    // setTimeout to prevent a React infinite recursion issue
     window.setTimeout(() => {
       this.context.resetBallot('/cast')
     }, 0)


### PR DESCRIPTION
apparently those warnings during tests can matter... this removes one of them and fixes an actual bug in the last screen. I'll work next to remove the remaining warning.