### PR TITLE
reset state appropriately when election mode toggles and on unconfigure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -329,6 +329,7 @@ export class App extends React.Component<RouteComponentProps, State> {
   public unconfigure = /* istanbul ignore next - triggering keystrokes issue - https://github.com/votingworks/bmd/issues/62 */ () => {
     this.setState(initialState)
     window.localStorage.removeItem(electionStorageKey)
+    window.localStorage.removeItem(stateStorageKey)
     this.resetVoterData()
     this.props.history.push('/')
   }
@@ -415,6 +416,7 @@ export class App extends React.Component<RouteComponentProps, State> {
       prevState => ({
         isLiveMode: !prevState.isLiveMode,
         ballotsPrintedCount: initialState.ballotsPrintedCount,
+        isPollsOpen: initialState.isPollsOpen,
       }),
       this.setStoredState
     )


### PR DESCRIPTION
resolves #423 

Also makes sure polls are closed on any mode change from testing to live and back.