### PR TITLE
make scrollbars invisible for test deck

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,11 @@ html {
   }
 }
 
+/* Make scrollbar invisible on test deck */
+.invisible-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 /* React Simple Keyboard */
 .simple-keyboard.hg-theme-default.vs-simple-keyboard {
   border-radius: 0;

--- a/src/pages/TestBallotDeckScreen.tsx
+++ b/src/pages/TestBallotDeckScreen.tsx
@@ -116,7 +116,7 @@ const TestBallotDeckScreen = ({
 
   return (
     <React.Fragment>
-      <Main>
+      <Main className="invisible-scrollbar">
         <MainChild maxWidth={false}>
           {ballots.length ? (
             <React.Fragment>


### PR DESCRIPTION

The scrollbar turns out to be something that appears as one big scrollbar that spans all the pages of the test deck. So I used this webkit magic to make the scrollbar invisible on the wrapping element.