### PR TITLE
Breadcrumbs should always have full page width.

### DIFF
--- a/src/pages/CastBallotPage.tsx
+++ b/src/pages/CastBallotPage.tsx
@@ -1,32 +1,3 @@
-// <Prose>
-//   <h1 aria-label="Verify and Cast Your Ballot.">
-//     Verify and Cast Your Ballot
-//   </h1>
-//   <Text center>Retrieve your printed ballot from the printer.</Text>
-//   <Instructions>
-//     {/* <li>
-//       <h2>Collect Printed Ballot.</h2>
-//       <p>The printer has printed your ballot.</p>
-//     </li> */}
-//     <li>
-//       <h2>Verify Ballot Selections.</h2>
-//       <p>Review and confirm all selections on your printed ballot.</p>
-//     </li>
-//     <li>
-//       <h2>Cast in Ballot Box.</h2>
-//       <p>Deposit your ballot into the secured ballot box.</p>
-//     </li>
-//   </Instructions>
-//   <Text center>
-//     I have verified my selections and will cast my ballot.
-//   </Text>
-//   <Text center>
-//     <LinkButton primary to="/">
-//       Start Over
-//     </LinkButton>
-//   </Text>
-// </Prose>
-
 import React, { useContext } from 'react'
 
 import Breadcrumbs from '../components/Breadcrumbs'
@@ -44,7 +15,7 @@ const VoteInstructionsPage = () => {
   return (
     <React.Fragment>
       <Main>
-        <MainChild center>
+        <MainChild centerVertical>
           <Breadcrumbs step={4} />
           <Prose textCenter id="audiofocus">
             <h1 aria-label="Cast your ballot.">Cast your printed ballot</h1>

--- a/src/pages/InstructionsPage.tsx
+++ b/src/pages/InstructionsPage.tsx
@@ -15,7 +15,7 @@ const InstructionsPage = () => {
   return (
     <React.Fragment>
       <Main>
-        <MainChild center id="audiofocus">
+        <MainChild centerVertical id="audiofocus">
           <Breadcrumbs step={1} />
           <Prose textCenter>
             <h1 aria-label="Mark your ballot.">Mark your ballot</h1>

--- a/src/pages/PreReviewPage.tsx
+++ b/src/pages/PreReviewPage.tsx
@@ -15,7 +15,7 @@ const SummaryPage = () => {
   return (
     <React.Fragment>
       <Main>
-        <MainChild center>
+        <MainChild centerVertical>
           <Breadcrumbs step={2} />
           <Prose textCenter id="audiofocus">
             <h1 aria-label="Review Your Selections.">Review Your Selections</h1>

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -55,7 +55,7 @@ class SummaryPage extends React.Component<RouteComponentProps, State> {
     return (
       <React.Fragment>
         <Main>
-          <MainChild center>
+          <MainChild centerVertical>
             <Breadcrumbs step={3} />
             <Prose textCenter className="no-print" id="audiofocus">
               <h1 aria-label="Print your official ballot.">


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/28444/58739067-41f2ce80-83bd-11e9-8139-a203a3903c3d.png)

## After

![image](https://user-images.githubusercontent.com/28444/58739088-5fc03380-83bd-11e9-9874-8cb6e87061e8.png)
