### PR TITLE
fixes for keyboard accessibility

### DIFF
--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -527,10 +527,10 @@ class CandidateContest extends React.Component<Props, State> {
                       })}
                   {contest.allowWriteIns && !hasReachedMaxSelections && (
                     <Choice
-                      as="button"
                       isSelected={false}
                       onClick={this.initWriteInCandidate}
                     >
+                      <ChoiceInput className="visually-hidden" />
                       <Prose>
                         <p aria-label="add write-in candidate.">
                           <em>add write-in candidate</em>
@@ -615,12 +615,13 @@ class CandidateContest extends React.Component<Props, State> {
           }
         />
         <Modal
+          ariaLabel=""
           isOpen={writeInCandateModalIsOpen}
           content={
             <div>
-              <Prose>
-                <h2>Write-In Candidate</h2>
-                <Text>
+              <Prose id="modalaudiofocus">
+                <h2 aria-label="Write-In Candidate.">Write-In Candidate</h2>
+                <Text aria-label="Enter the name of a person who is not on the ballot. Use the up and down arrows to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
                   Enter the name of a person who is <strong>not</strong> on the
                   ballot using the on-screen keyboard.
                 </Text>
@@ -645,6 +646,7 @@ class CandidateContest extends React.Component<Props, State> {
                   </legend>
                   <WriteInCandidateInput
                     id="WriteInCandidateName"
+                    aria-label="Name of Write-in Candidate."
                     value={writeInCandidateName}
                     placeholder="candidate name"
                   />

--- a/src/components/VirtualKeyboard.tsx
+++ b/src/components/VirtualKeyboard.tsx
@@ -57,7 +57,12 @@ const VirtualKeyboard = ({ onKeyPress }: Props) => (
       return (
         <div key={String(`row${i}`)}>
           {row.map((key: string) => (
-            <Button key={key} data-key={key} onClick={onKeyPress}>
+            <Button
+              key={key}
+              data-key={key}
+              aria-label={key.toLowerCase()}
+              onClick={onKeyPress}
+            >
               {key}
             </Button>
           ))}

--- a/src/lib/gamepad.ts
+++ b/src/lib/gamepad.ts
@@ -54,8 +54,11 @@ function handleArrowRight() {
   }
 }
 
-function handleClick() {
-  getActiveElement().click()
+function handleClick(sendEvenIfButton: boolean) {
+  const activeElement = getActiveElement()
+  if (activeElement.type !== 'button' || sendEvenIfButton) {
+    activeElement.click()
+  }
 }
 
 export function handleGamepadButtonDown(buttonName: string) {
@@ -74,7 +77,7 @@ export function handleGamepadButtonDown(buttonName: string) {
       handleArrowRight()
       break
     case 'A':
-      handleClick()
+      handleClick(true)
       break
     // no default
   }
@@ -100,8 +103,10 @@ export /* istanbul ignore next - triggering keystrokes issue - https://github.co
       handleArrowRight()
       break
     case ']':
+      handleClick(true)
+      break
     case 'Enter':
-      handleClick()
+      handleClick(false)
       break
     // no default
   }


### PR DESCRIPTION
few audio fixes.

Most important to review: buttons are causing issue with the "return" key on accessibility, because the natural event is doubling up on the synthetic event we generate. This wasn't much of an issue till now, but with the virtual keyboard as buttons, it was doubling up letters. This isn't the least risky change I've made, so worth a review. For what it's worth the ballot accessibility still works.