### PR TITLE
Fix typo in `App` lifecycle method name.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,7 +233,7 @@ export class App extends React.Component<RouteComponentProps, State> {
     this.startPolling()
   }
 
-  public componentWillUnount = /* istanbul ignore next - triggering keystrokes issue - https://github.com/votingworks/bmd/issues/62 */ () => {
+  public componentWillUnmount = /* istanbul ignore next - triggering keystrokes issue - https://github.com/votingworks/bmd/issues/62 */ () => {
     Mousetrap.unbind(removeElectionShortcuts)
     document.removeEventListener('keydown', handleGamepadKeyboardEvent)
     window.clearInterval(checkCardInterval)


### PR DESCRIPTION
## Related Issue(s)

n/a

Resolves #1

## Description

I'm guessing this hasn't been an issue because the root `App` component never actually gets unmounted.

## Screenshots/Screencasts

n/a

## Types of changes

- [X] Bug fix.
- [ ] New feature or updated functionality.

**Is this a breaking change?** eg. Will this change require updates to existing
election configuration files?

- [ ] Yes, this is a breaking change.

## Checklist:

<!-- Put an `x` in all the boxes that apply. -->
<!-- If unsure about any, don't hesitate to ask. We're here to help! -->

- [X] This code follows the code style of this project.
- [ ] This change requires a change to the documentation.
- [ ] The documentation has been updated accordingly.
- [X] I have read the
      [CONTRIBUTING](https://github.com/votingworks/bmd/blob/master/CONTRIBUTING.md)
      document.
- [X] Tests have been updated to cover new/changed functionality.
- [X] All new and existing tests have passed.
