### PR TITLE
Improve screenreader pronunciation of onscreen keyboard.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,13 +113,16 @@ html {
 }
 .simple-keyboard.vs-simple-keyboard .hg-button {
   flex: 1;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 .simple-keyboard.vs-simple-keyboard .hg-button-space {
   flex: 3;
+  text-transform: inherit;
 }
 .simple-keyboard.vs-simple-keyboard .hg-button-bksp {
   flex: 2;
+  text-transform: inherit;
 }
 .simple-keyboard.vs-simple-keyboard .hg-row:nth-child(2) {
   margin-right: 0;

--- a/src/AppContestWriteIn.test.tsx
+++ b/src/AppContestWriteIn.test.tsx
@@ -50,9 +50,9 @@ it(`Write-In Candidate flow with single seat contest`, () => {
   // Add Write-In Candidate
   fireEvent.click(getByText('add write-in candidate').closest('button')!)
   expect(getByText('Write-In Candidate')).toBeTruthy()
-  fireEvent.click(getByText('B').closest('button')!)
-  fireEvent.click(getByText('O').closest('button')!)
-  fireEvent.click(getByText('B').closest('button')!)
+  fireEvent.click(getByText('b').closest('button')!)
+  fireEvent.click(getByText('o').closest('button')!)
+  fireEvent.click(getByText('b').closest('button')!)
   fireEvent.click(getByText('Accept'))
 
   // Remove Write-In Candidate
@@ -61,9 +61,9 @@ it(`Write-In Candidate flow with single seat contest`, () => {
 
   // Add Different Write-In Candidate
   fireEvent.click(getByText('add write-in candidate').closest('button')!)
-  fireEvent.click(getByText('S').closest('button')!)
-  fireEvent.click(getByText('A').closest('button')!)
-  fireEvent.click(getByText('L').closest('button')!)
+  fireEvent.click(getByText('s').closest('button')!)
+  fireEvent.click(getByText('a').closest('button')!)
+  fireEvent.click(getByText('l').closest('button')!)
   fireEvent.click(getByText('Accept'))
   expect(
     (getByText('SAL')

--- a/src/components/CandidateContest.test.tsx
+++ b/src/components/CandidateContest.test.tsx
@@ -155,7 +155,7 @@ describe(`supports write-in candidates`, () => {
     )
     fireEvent.click(getByText('add write-in candidate').closest('button')!)
     expect(getByText('Write-In Candidate')).toBeTruthy()
-    Array.from('JACOB JOHANSON JINGLEHEIMMER SCHMIDTT').forEach(i => {
+    Array.from('jacob johanson jingleheimmer schmidtt').forEach(i => {
       const key = i === ' ' ? 'space' : i
       fireEvent.click(getByText(key).closest('button')!)
     })

--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -320,6 +320,7 @@ class CandidateContest extends React.Component<Props, State> {
       .trim()
       .replace(/\t+/g, ' ')
       .replace(/\s+/g, ' ')
+      .toUpperCase()
 
   public addWriteInCandidate = () => {
     const { contest, vote } = this.props
@@ -348,7 +349,8 @@ class CandidateContest extends React.Component<Props, State> {
   }
 
   public onKeyboardInputChange = (writeInCandidateName: string) => {
-    this.setState({ writeInCandidateName })
+    const normalizedCandidateName = this.normalizeName(writeInCandidateName)
+    this.setState({ writeInCandidateName: normalizedCandidateName })
   }
 
   public updateContestChoicesScrollStates = () => {
@@ -644,9 +646,9 @@ class CandidateContest extends React.Component<Props, State> {
                   ref={this.keyboard}
                   layout={{
                     default: [
-                      'Q W E R T Y U I O P',
-                      'A S D F G H J K L -',
-                      'Z X C V B N M , .',
+                      'q w e r t y u i o p',
+                      'a s d f g h j k l -',
+                      'z x c v b n m , .',
                       '{space} {bksp}',
                     ],
                   }}


### PR DESCRIPTION
It seems that screenreaders attempt to emphasize uppercase letters, leading to a somewhat jarring pronunciation of the individual keys available on the onscreen keyboard. The solution here is a straightforward one: use lowercase letters, but maintain the uppercase presentation by using text-transform.

bmd/518

<!--

Hi! We’re stoked that you would like to submit a pull request!

In order to get your pull request reviewed and merged, please fill out as much
of the below template as you can. Feel fre to ignore any part of this template
which does not pertain to your code.

If you have any questions, please ask us. We're here to help!

-->

<!-- Provide a general summary of the changes in the Title above. -->

## Related Issue(s)

<!-- Please link to the issue(s) where this feature/bug is discussed/reported. -->

(Partially) Resolves #518 

## Description

<!--
If not clearly described in the related issue(s), describe:
- Why this change is propsed?
- What issue/bug does it solve?
-->

## Screenshots/Screencasts

<!-- Copy/paste or drag/drop images/videos here to assist in reviewing this pull request. -->

## Types of changes

<!--
What types of changes does your code introduce?
Put an `x` in all the boxes that apply.
-->

- [ ] Bug fix.
- [X] New feature or updated functionality.

**Is this a breaking change?** eg. Will this change require updates to existing
election configuration files?

- [ ] Yes, this is a breaking change.

<!-- If so, describe what will break and steps to fix. -->

## Checklist:

<!-- Put an `x` in all the boxes that apply. -->
<!-- If unsure about any, don't hesitate to ask. We're here to help! -->

- [X] This code follows the code style of this project.
- [ ] This change requires a change to the documentation.
- [ ] The documentation has been updated accordingly.
- [X] I have read the
      [CONTRIBUTING](https://github.com/votingworks/bmd/blob/master/CONTRIBUTING.md)
      document.
- [X] Tests have been updated to cover new/changed functionality.
- [X] All new and existing tests have passed.
