### PR TITLE
refactor: clean up types in `isJSON` utils

### DIFF
--- a/src/utils/isJSON.test.ts
+++ b/src/utils/isJSON.test.ts
@@ -49,4 +49,5 @@ it(`perform isJSON verifications`, () => {
     })
   ).toBeTruthy()
   expect(isJSONStrict('asdf')).toBeFalsy()
+  expect(isJSONStrict(true)).toBeFalsy()
 })

--- a/src/utils/isJSON.ts
+++ b/src/utils/isJSON.ts
@@ -1,50 +1,46 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // Ported to TypeScript from:
 // https://github.com/joaquimserafim/isJSON
 
-function isString(x: string) {
+function isString(x: unknown): x is string {
   return Object.prototype.toString.call(x) === '[object String]'
 }
 
-function isObject(obj: {}) {
+function isObject(obj: unknown): obj is object {
   return Object.prototype.toString.call(obj) === '[object Object]'
 }
 
-function isJSON(str: any, passObject?: boolean): boolean {
-  if (passObject && isObject(str)) {
+function isJSON(value: unknown, passObject: boolean = false): boolean {
+  if (passObject && isObject(value)) {
     return true
   }
 
-  if (!isString(str)) {
+  if (!isString(value)) {
     return false
   }
 
-  str = str.replace(/\s/g, '').replace(/\n|\r/, '')
+  const str = value.replace(/\s/g, '').replace(/\n|\r/, '')
 
   if (/^\{(.*?)\}$/.test(str)) {
     return /"(.*?)":(.*?)/g.test(str)
   }
 
   if (/^\[(.*?)\]$/.test(str)) {
-    return (
-      str
-        .replace(/^\[/, '')
-        .replace(/\]$/, '')
-        .replace(/},{/g, '}\n{')
-        .split(/\n/)
-        .map((s: any) => isJSON(s))
-        // @ts-ignore: 'prev' must be defined but is unused.
-        .reduce((prev: any, curr: any) => !!curr)
-    )
+    return str
+      .replace(/^\[/, '')
+      .replace(/\]$/, '')
+      .replace(/},{/g, '}\n{')
+      .split(/\n/)
+      .every(s => isJSON(s))
   }
 
   return false
 }
 
-export function isJSONStrict(str: any) {
+export function isJSONStrict(str: unknown): boolean {
   if (isObject(str)) {
     return true
+  } else if (!isString(str)) {
+    return false
   }
 
   try {


### PR DESCRIPTION
This gets rid of `any` and replaces it with [`unknown`][unknown] as appropriate. Using `unknown` is better because it is the _least_ capable type rather than `any` which is the _most_ capable type. This commit changes `isString` and `isObject` to be [type predicates][type predicates] which allows TS to infer types of arguments based on the return value, so `unknown` can be implicitly cast to `string` or `object` when control flow is based on the results of `isString` and `isObject`. Note that `isString` is not really necessary since `typeof value === 'string'` does the same thing, but I left it to minimize changes to this file.

`passObject` now has a default value of `false` just to simplify its type from `boolean | undefined` to just `boolean` while keeping the API the same.

Using `.map((s: any) => isJSON(s)).reduce((prev: any, curr: any) => !!curr)` is not good for a few reasons:
- all those `any` type annotations are unnecessary
- using `Array#reduce` where `prev` is ignored is a hint that there's a more appropriate method to use, in this case `Array#every`
- using `!!` on array entries is redundant when they are guaranteed to be `boolean` values because they come from `isJSON`

[unknown]: https://devblogs.microsoft.com/typescript/announcing-typescript-3-0-rc-2/#the-unknown-type
[type predicates]: http://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates