### PR TITLE
don't double handle the click of an Enter key

### DIFF
--- a/src/lib/gamepad.ts
+++ b/src/lib/gamepad.ts
@@ -105,7 +105,8 @@ export /* istanbul ignore next - triggering keystrokes issue - https://github.co
       handleClick()
       break
     case 'Enter':
-      handleClick()
+      // Enter already acts like a click
+      // handleClick()
       break
     // no default
   }


### PR DESCRIPTION
'Enter' key on accessible controller wasn't working because we were artificially handling the click a second time. Let's not do that, 'Enter' does it all by itself