### PR TITLE
better touch via pointer events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,11 @@ import Screen from './components/Screen'
 
 import AppRoot from './AppRoot'
 
+/* istanbul ignore next - unsure how to test */
+window.oncontextmenu = (e: MouseEvent): void => {
+  e.preventDefault()
+}
+
 const App = () => (
   <BrowserRouter>
     <Screen>

--- a/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -72,6 +72,30 @@ exports[`Single Seat Contest 1`] = `
   margin: 0.25rem;
 }
 
+.c13 {
+  border: none;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  background: rgb(71,167,75);
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  line-height: 1.25;
+  color: #FFFFFF;
+  touch-action: manipulation;
+}
+
+.c14 {
+  border: none;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  background: rgb(211,211,211);
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  line-height: 1.25;
+  color: black;
+  touch-action: manipulation;
+}
+
 .c11 {
   position: relative;
   border-radius: 0.125rem;
@@ -153,30 +177,6 @@ exports[`Single Seat Contest 1`] = `
   font-size: 2rem;
   font-weight: 700;
   content: '✓';
-}
-
-.c13 {
-  border: none;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  background: rgb(71,167,75);
-  cursor: pointer;
-  padding: 0.75rem 1rem;
-  line-height: 1.25;
-  color: #FFFFFF;
-  touch-action: manipulation;
-}
-
-.c14 {
-  border: none;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  background: rgb(211,211,211);
-  cursor: pointer;
-  padding: 0.75rem 1rem;
-  line-height: 1.25;
-  color: black;
-  touch-action: manipulation;
 }
 
 .c1 {

--- a/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -481,7 +481,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Camille Argent, Federalist."
               class="c9"
-              data-id="argent"
+              data-choice="argent"
               data-selected="true"
               role="option"
               type="button"
@@ -503,7 +503,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Chloe Witherspoon-Smithson, Federalist."
               class="c9"
-              data-id="witherspoonsmithson"
+              data-choice="witherspoonsmithson"
               data-selected="true"
               role="option"
               type="button"
@@ -525,7 +525,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Clayton Bainbridge, Federalist."
               class="c9"
-              data-id="bainbridge"
+              data-choice="bainbridge"
               data-selected="true"
               role="option"
               type="button"
@@ -547,7 +547,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Charlene Hennessey, People's."
               class="c9"
-              data-id="hennessey"
+              data-choice="hennessey"
               data-selected="true"
               role="option"
               type="button"
@@ -569,7 +569,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Eric Savoy, People's."
               class="c11"
-              data-id="savoy"
+              data-choice="savoy"
               data-selected="false"
               role="option"
               type="button"
@@ -591,7 +591,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Susan Tawa, People's."
               class="c11"
-              data-id="tawa"
+              data-choice="tawa"
               data-selected="false"
               role="option"
               type="button"
@@ -613,7 +613,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Mary Tawa, People's."
               class="c11"
-              data-id="tawa-mary"
+              data-choice="tawa-mary"
               data-selected="false"
               role="option"
               type="button"
@@ -635,7 +635,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Damian Rangel, Liberty."
               class="c11"
-              data-id="rangel"
+              data-choice="rangel"
               data-selected="false"
               role="option"
               type="button"
@@ -657,7 +657,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Valarie Altman, Constitution."
               class="c11"
-              data-id="altman"
+              data-choice="altman"
               data-selected="false"
               role="option"
               type="button"
@@ -679,7 +679,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Helen Moore, Constitution."
               class="c11"
-              data-id="moore"
+              data-choice="moore"
               data-selected="false"
               role="option"
               type="button"
@@ -701,7 +701,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="John White, Whig."
               class="c11"
-              data-id="white"
+              data-choice="white"
               data-selected="false"
               role="option"
               type="button"
@@ -723,7 +723,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Joe Schmidt, Whig."
               class="c11"
-              data-id="schmidt"
+              data-choice="schmidt"
               data-selected="false"
               role="option"
               type="button"
@@ -745,7 +745,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Joe Smith, Whig."
               class="c11"
-              data-id="smith"
+              data-choice="smith"
               data-selected="false"
               role="option"
               type="button"
@@ -767,7 +767,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Amanda Marracini, Labor."
               class="c11"
-              data-id="marracini"
+              data-choice="marracini"
               data-selected="false"
               role="option"
               type="button"
@@ -789,7 +789,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Martin Schreiner, Independent."
               class="c11"
-              data-id="schreiner"
+              data-choice="schreiner"
               data-selected="false"
               role="option"
               type="button"

--- a/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
@@ -481,7 +481,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Joseph Barchi and Joseph Hallaren, Federalist."
               class="c9"
-              data-id="barchi-hallaren"
+              data-choice="barchi-hallaren"
               data-selected="true"
               role="option"
               type="button"
@@ -503,7 +503,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Adam Cramer and Greg Vuocolo, People's."
               class="c11"
-              data-id="cramer-vuocolo"
+              data-choice="cramer-vuocolo"
               data-selected="false"
               role="option"
               type="button"
@@ -525,7 +525,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Daniel Court and Amy Blumhardt, Liberty."
               class="c11"
-              data-id="court-blumhardt"
+              data-choice="court-blumhardt"
               data-selected="false"
               role="option"
               type="button"
@@ -547,7 +547,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Alvin Boone and James Lian, Constitution."
               class="c11"
-              data-id="boone-lian"
+              data-choice="boone-lian"
               data-selected="false"
               role="option"
               type="button"
@@ -569,7 +569,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Ashley Hildebrand-McDougall and James Garritty, Whig."
               class="c11"
-              data-id="hildebrand-garritty"
+              data-choice="hildebrand-garritty"
               data-selected="false"
               role="option"
               type="button"
@@ -591,7 +591,7 @@ exports[`Single Seat Contest 1`] = `
             <button
               aria-label="Martin Patterson and Clay Lariviere, Labor."
               class="c11"
-              data-id="patterson-lariviere"
+              data-choice="patterson-lariviere"
               data-selected="false"
               role="option"
               type="button"

--- a/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
@@ -72,6 +72,30 @@ exports[`Single Seat Contest 1`] = `
   margin: 0.25rem;
 }
 
+.c13 {
+  border: none;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  background: rgb(71,167,75);
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  line-height: 1.25;
+  color: #FFFFFF;
+  touch-action: manipulation;
+}
+
+.c14 {
+  border: none;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  background: rgb(211,211,211);
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  line-height: 1.25;
+  color: black;
+  touch-action: manipulation;
+}
+
 .c11 {
   position: relative;
   border-radius: 0.125rem;
@@ -153,30 +177,6 @@ exports[`Single Seat Contest 1`] = `
   font-size: 2rem;
   font-weight: 700;
   content: '✓';
-}
-
-.c13 {
-  border: none;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  background: rgb(71,167,75);
-  cursor: pointer;
-  padding: 0.75rem 1rem;
-  line-height: 1.25;
-  color: #FFFFFF;
-  touch-action: manipulation;
-}
-
-.c14 {
-  border: none;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  background: rgb(211,211,211);
-  cursor: pointer;
-  padding: 0.75rem 1rem;
-  line-height: 1.25;
-  color: black;
-  touch-action: manipulation;
 }
 
 .c1 {

--- a/src/__snapshots__/AppContestWriteIn.test.tsx.snap
+++ b/src/__snapshots__/AppContestWriteIn.test.tsx.snap
@@ -72,6 +72,18 @@ exports[`Single Seat Contest with Write In 1`] = `
   margin: 0.25rem;
 }
 
+.c12 {
+  border: none;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  background: rgb(211,211,211);
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  line-height: 1.25;
+  color: black;
+  touch-action: manipulation;
+}
+
 .c9 {
   position: relative;
   border-radius: 0.125rem;
@@ -111,18 +123,6 @@ exports[`Single Seat Contest with Write In 1`] = `
   font-size: 2rem;
   font-weight: 700;
   content: '';
-}
-
-.c12 {
-  border: none;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  background: rgb(211,211,211);
-  cursor: pointer;
-  padding: 0.75rem 1rem;
-  line-height: 1.25;
-  color: black;
-  touch-action: manipulation;
 }
 
 .c1 {

--- a/src/__snapshots__/AppContestWriteIn.test.tsx.snap
+++ b/src/__snapshots__/AppContestWriteIn.test.tsx.snap
@@ -421,7 +421,7 @@ exports[`Single Seat Contest with Write In 1`] = `
             <button
               aria-label="Rhadka Ramachandrani, Independent."
               class="c9"
-              data-id="ramachandrani"
+              data-choice="ramachandrani"
               data-selected="false"
               role="option"
               type="button"
@@ -442,6 +442,7 @@ exports[`Single Seat Contest with Write In 1`] = `
             </button>
             <button
               class="c9"
+              data-choice="write-in"
               data-selected="false"
               role="option"
               type="button"

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -62,17 +62,24 @@ it('works properly with clicks and touches', () => {
   fireEvent.pointerDown(button)
   expect(onPress).toHaveBeenCalledTimes(2)
 
-  // this is the behavior when a proper touch becomes a click
+  // when a tap is not smudged and doesn't last too long
+  // we get pointerDown, pointerUp, and finally a click event.
+  // in this case, we only want onPress to fire once.
   fireEvent.pointerDown(button)
   fireEvent.pointerUp(button)
   fireEvent.click(button)
   expect(onPress).toHaveBeenCalledTimes(3)
 
-  // this is the behavior on a bad touch, followed by a separate click
-  // so this ends up calling the event handler twice
+  // when a tap is smudged or lasts too long,
+  // we get pointerDown, pointerCancel, and no click event.
+  // we still want onPress to fire exactly once.
   fireEvent.pointerDown(button)
   fireEvent.pointerCancel(button)
   expect(onPress).toHaveBeenCalledTimes(4)
+
+  // on use of accessible controller / keyboard
+  // we get just a click event.
+  // this should trigger onPress exactly once.
   fireEvent.click(button)
   expect(onPress).toHaveBeenCalledTimes(5)
 })

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 
 import Button, { DecoyButton } from './Button'
 
@@ -49,4 +49,29 @@ it('renders small Button', () => {
 it('renders DecoyButton', () => {
   const { container } = render(<DecoyButton>DecoyButton</DecoyButton>)
   expect(container.firstChild).toMatchSnapshot()
+})
+
+it('works properly with clicks and touches', () => {
+  const onPress = jest.fn()
+  const { getByText } = render(<Button onPress={onPress}>Test Button</Button>)
+  const button = getByText('Test Button')
+
+  fireEvent.click(button)
+  expect(onPress).toHaveBeenCalledTimes(1)
+
+  fireEvent.pointerDown(button)
+  expect(onPress).toHaveBeenCalledTimes(2)
+
+  // this is the behavior when a proper touch becomes a click
+  fireEvent.pointerDown(button)
+  fireEvent.pointerUp(button)
+  fireEvent.click(button)
+  expect(onPress).toHaveBeenCalledTimes(3)
+
+  // this is the behavior on a bad touch, followed by a separate click
+  // so this ends up calling the event handler twice
+  fireEvent.pointerDown(button)
+  fireEvent.pointerCancel(button)
+  fireEvent.click(button)
+  expect(onPress).toHaveBeenCalledTimes(5)
 })

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -72,6 +72,7 @@ it('works properly with clicks and touches', () => {
   // so this ends up calling the event handler twice
   fireEvent.pointerDown(button)
   fireEvent.pointerCancel(button)
+  expect(onPress).toHaveBeenCalledTimes(4)
   fireEvent.click(button)
   expect(onPress).toHaveBeenCalledTimes(5)
 })

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -13,11 +13,11 @@ export interface ButtonInterface {
   readonly big?: boolean
 }
 
-interface Props
+interface StyledButtonProps
   extends ButtonInterface,
     React.PropsWithoutRef<JSX.IntrinsicElements['button']> {}
 
-const buttonStyles = css<Props>`
+const buttonStyles = css<StyledButtonProps>`
   border: none;
   border-radius: 0.25rem;
   box-sizing: border-box;
@@ -49,8 +49,8 @@ const StyledButton = styled('button').attrs((props: Attrs) => ({
   ${buttonStyles} /* stylelint-disable-line value-keyword-case */
 `
 
-interface PointerButtonProps extends Props {
-  component?: StyledComponent<'button', never, Props, never>
+export interface Props extends StyledButtonProps {
+  component?: StyledComponent<'button', never, StyledButtonProps, never>
   onPress: MouseEventHandler
 }
 
@@ -58,7 +58,7 @@ const Button = ({
   component: Component = StyledButton,
   onPress,
   ...rest
-}: PointerButtonProps) => {
+}: Props) => {
   const [readyForEvents, setReadyForEvents] = useState(true)
 
   const onPointerUp = () => setReadyForEvents(false)

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEventHandler, useState } from 'react'
-import styled, { css } from 'styled-components'
+import styled, { css, StyledComponent } from 'styled-components'
 
 interface Attrs extends HTMLButtonElement {
   readonly type: string
@@ -50,10 +50,15 @@ const StyledButton = styled('button').attrs((props: Attrs) => ({
 `
 
 interface PointerButtonProps extends Props {
+  component?: StyledComponent<'button', never, Props, never>
   onPress: MouseEventHandler
 }
 
-const Button = ({ onPress, ...rest }: PointerButtonProps) => {
+const Button = ({
+  component: Component = StyledButton,
+  onPress,
+  ...rest
+}: PointerButtonProps) => {
   const [readyForEvents, setReadyForEvents] = useState(true)
 
   const onPointerUp = () => setReadyForEvents(false)
@@ -67,7 +72,7 @@ const Button = ({ onPress, ...rest }: PointerButtonProps) => {
   }
 
   return (
-    <StyledButton
+    <Component
       {...rest}
       onPointerDown={onPress}
       onPointerUp={onPointerUp}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler } from 'react'
+import React, { MouseEventHandler, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 interface Attrs extends HTMLButtonElement {
@@ -53,9 +53,28 @@ interface PointerButtonProps extends Props {
   onPress: MouseEventHandler
 }
 
-const Button = ({ onPress, ...rest }: PointerButtonProps) => (
-  <StyledButton {...rest} onClick={onPress} />
-)
+const Button = ({ onPress, ...rest }: PointerButtonProps) => {
+  const [readyForEvents, setReadyForEvents] = useState(true)
+
+  const onPointerUp = () => setReadyForEvents(false)
+
+  const onClick = (event: React.MouseEvent) => {
+    if (readyForEvents) {
+      onPress(event)
+    } else {
+      setReadyForEvents(true)
+    }
+  }
+
+  return (
+    <StyledButton
+      {...rest}
+      onPointerDown={onPress}
+      onPointerUp={onPointerUp}
+      onClick={onClick}
+    />
+  )
+}
 
 export const SegmentedButton = styled.span`
   display: inline-block;

--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -224,7 +224,7 @@ class CandidateContest extends React.Component<Props, State> {
 
   public handleUpdateSelection = (event: InputEvent) => {
     const { vote } = this.props
-    const candidateId = (event.currentTarget as HTMLInputElement).dataset.id
+    const candidateId = (event.currentTarget as HTMLInputElement).dataset.choice
     /* istanbul ignore else */
     if (candidateId) {
       const candidate = this.findCandidateById(vote, candidateId)
@@ -440,7 +440,7 @@ class CandidateContest extends React.Component<Props, State> {
                             ? handleDisabledClick
                             : this.handleUpdateSelection
                         }
-                        data-id={candidate.id}
+                        choice={candidate.id}
                         aria-label={`${stripQuotes(
                           candidate.name
                         )}, ${partyName}.`}
@@ -463,7 +463,7 @@ class CandidateContest extends React.Component<Props, State> {
                           <ChoiceButton
                             key={candidate.id}
                             isSelected
-                            data-id={candidate.id}
+                            choice={candidate.id}
                             onPress={this.handleUpdateSelection}
                           >
                             <Prose>
@@ -476,6 +476,7 @@ class CandidateContest extends React.Component<Props, State> {
                       })}
                   {contest.allowWriteIns && !hasReachedMaxSelections && (
                     <ChoiceButton
+                      choice="write-in"
                       isSelected={false}
                       onPress={this.initWriteInCandidate}
                     >

--- a/src/components/ChoiceButton.test.tsx
+++ b/src/components/ChoiceButton.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+
+import ChoiceButton from './ChoiceButton'
+
+const onPress = jest.fn()
+
+it('renders ChoiceButton', () => {
+  const { container } = render(
+    <ChoiceButton isSelected={false} onPress={onPress}>
+      foo
+    </ChoiceButton>
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})
+
+it('works properly with clicks and touches', () => {
+  const onPress = jest.fn()
+  const { getByText } = render(
+    <ChoiceButton isSelected={false} onPress={onPress}>
+      Test Button
+    </ChoiceButton>
+  )
+  const button = getByText('Test Button')
+
+  fireEvent.click(button)
+  expect(onPress).toHaveBeenCalledTimes(1)
+
+  fireEvent.pointerDown(button)
+  expect(onPress).toHaveBeenCalledTimes(2)
+
+  // this is the behavior when a proper touch becomes a click
+  fireEvent.pointerDown(button)
+  fireEvent.pointerUp(button)
+  fireEvent.click(button)
+  expect(onPress).toHaveBeenCalledTimes(3)
+
+  // this is the behavior on a bad touch, followed by a separate click
+  // so this ends up calling the event handler twice
+  fireEvent.pointerDown(button)
+  fireEvent.pointerCancel(button)
+  fireEvent.click(button)
+  expect(onPress).toHaveBeenCalledTimes(5)
+})

--- a/src/components/ChoiceButton.test.tsx
+++ b/src/components/ChoiceButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import ChoiceButton from './ChoiceButton'
 
@@ -12,33 +12,4 @@ it('renders ChoiceButton', () => {
     </ChoiceButton>
   )
   expect(container.firstChild).toMatchSnapshot()
-})
-
-it('works properly with clicks and touches', () => {
-  const onPress = jest.fn()
-  const { getByText } = render(
-    <ChoiceButton isSelected={false} onPress={onPress}>
-      Test Button
-    </ChoiceButton>
-  )
-  const button = getByText('Test Button')
-
-  fireEvent.click(button)
-  expect(onPress).toHaveBeenCalledTimes(1)
-
-  fireEvent.pointerDown(button)
-  expect(onPress).toHaveBeenCalledTimes(2)
-
-  // this is the behavior when a proper touch becomes a click
-  fireEvent.pointerDown(button)
-  fireEvent.pointerUp(button)
-  fireEvent.click(button)
-  expect(onPress).toHaveBeenCalledTimes(3)
-
-  // this is the behavior on a bad touch, followed by a separate click
-  // so this ends up calling the event handler twice
-  fireEvent.pointerDown(button)
-  fireEvent.pointerCancel(button)
-  fireEvent.click(button)
-  expect(onPress).toHaveBeenCalledTimes(5)
 })

--- a/src/components/ChoiceButton.test.tsx
+++ b/src/components/ChoiceButton.test.tsx
@@ -7,7 +7,7 @@ const onPress = jest.fn()
 
 it('renders ChoiceButton', () => {
   const { container } = render(
-    <ChoiceButton isSelected={false} onPress={onPress}>
+    <ChoiceButton choice="foo" isSelected={false} onPress={onPress}>
       foo
     </ChoiceButton>
   )

--- a/src/components/ChoiceButton.tsx
+++ b/src/components/ChoiceButton.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler } from 'react'
+import React, { MouseEventHandler, useState } from 'react'
 import styled from 'styled-components'
 
 import * as GLOBALS from '../config/globals'
@@ -56,12 +56,28 @@ interface ChoiceButtonProps extends StyledChoiceButtonProps {
   onPress: MouseEventHandler
 }
 
-const ChoiceButton = ({ onPress, ...rest }: ChoiceButtonProps) => (
-  <StyledChoiceButton
-    {...rest}
-    data-selected={rest.isSelected}
-    onClick={onPress}
-  />
-)
+const ChoiceButton = ({ onPress, ...rest }: ChoiceButtonProps) => {
+  const [readyForEvents, setReadyForEvents] = useState(true)
+
+  const onPointerUp = () => setReadyForEvents(false)
+
+  const onClick = (event: React.MouseEvent) => {
+    if (readyForEvents) {
+      onPress(event)
+    } else {
+      setReadyForEvents(true)
+    }
+  }
+
+  return (
+    <StyledChoiceButton
+      {...rest}
+      data-selected={rest.isSelected}
+      onPointerDown={onPress}
+      onPointerUp={onPointerUp}
+      onClick={onClick}
+    />
+  )
+}
 
 export default ChoiceButton

--- a/src/components/ChoiceButton.tsx
+++ b/src/components/ChoiceButton.tsx
@@ -1,23 +1,25 @@
-import React, { MouseEventHandler } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import * as GLOBALS from '../config/globals'
 
-import Button from './Button'
+import Button, { Props as ButtonProps } from './Button'
 
 interface Attrs extends HTMLButtonElement {
   readonly type: string
 }
 
-interface StyledChoiceButtonProps
-  extends React.PropsWithoutRef<JSX.IntrinsicElements['button']> {
+interface Props
+  extends ButtonProps,
+    React.PropsWithoutRef<JSX.IntrinsicElements['button']> {
+  choice: string
   isSelected: boolean
 }
 
 const StyledChoiceButton = styled('button').attrs((props: Attrs) => ({
   role: 'option',
   type: props.type || 'button',
-}))<StyledChoiceButtonProps>`
+}))<Props>`
   position: relative;
   border-radius: 0.125rem;
   box-shadow: 0 0.125rem 0.125rem 0 rgba(0, 0, 0, 0.14),
@@ -54,18 +56,13 @@ const StyledChoiceButton = styled('button').attrs((props: Attrs) => ({
   }
 `
 
-interface ChoiceButtonProps extends StyledChoiceButtonProps {
-  onPress: MouseEventHandler
-  dataSelected?: boolean
-}
-
-const ChoiceButton = ({ onPress, ...rest }: ChoiceButtonProps) => {
+const ChoiceButton = ({ choice, ...rest }: Props) => {
   return (
     <Button
       {...rest}
       component={StyledChoiceButton}
+      data-choice={choice}
       data-selected={rest.isSelected}
-      onPress={onPress}
     />
   )
 }

--- a/src/components/ChoiceButton.tsx
+++ b/src/components/ChoiceButton.tsx
@@ -1,7 +1,9 @@
-import React, { MouseEventHandler, useState } from 'react'
+import React, { MouseEventHandler } from 'react'
 import styled from 'styled-components'
 
 import * as GLOBALS from '../config/globals'
+
+import Button from './Button'
 
 interface Attrs extends HTMLButtonElement {
   readonly type: string
@@ -54,28 +56,16 @@ const StyledChoiceButton = styled('button').attrs((props: Attrs) => ({
 
 interface ChoiceButtonProps extends StyledChoiceButtonProps {
   onPress: MouseEventHandler
+  dataSelected?: boolean
 }
 
 const ChoiceButton = ({ onPress, ...rest }: ChoiceButtonProps) => {
-  const [readyForEvents, setReadyForEvents] = useState(true)
-
-  const onPointerUp = () => setReadyForEvents(false)
-
-  const onClick = (event: React.MouseEvent) => {
-    if (readyForEvents) {
-      onPress(event)
-    } else {
-      setReadyForEvents(true)
-    }
-  }
-
   return (
-    <StyledChoiceButton
+    <Button
       {...rest}
+      component={StyledChoiceButton}
       data-selected={rest.isSelected}
-      onPointerDown={onPress}
-      onPointerUp={onPointerUp}
-      onClick={onClick}
+      onPress={onPress}
     />
   )
 }

--- a/src/components/YesNoContest.tsx
+++ b/src/components/YesNoContest.tsx
@@ -185,7 +185,7 @@ export default class YesNoContest extends React.Component<Props> {
   public handleUpdateSelection = (event: InputEvent) => {
     const { vote } = this.props
     const newVote = (event.currentTarget as HTMLInputElement).dataset
-      .vote as YesNoVote
+      .choice as YesNoVote
     if (vote === newVote) {
       this.props.updateVote(this.props.contest.id, undefined)
     } else {
@@ -322,7 +322,7 @@ export default class YesNoContest extends React.Component<Props> {
                 return (
                   <ChoiceButton
                     key={answer}
-                    data-vote={answerLowerCase}
+                    choice={answerLowerCase}
                     isSelected={isChecked}
                     onPress={
                       isDisabled

--- a/src/components/__snapshots__/CandidateContest.test.tsx.snap
+++ b/src/components/__snapshots__/CandidateContest.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`supports multi-seat contests allows a second candidate to be selected w
             <button
               aria-label="Name 0, Party 0."
               class="c8"
-              data-id="name-0"
+              data-choice="name-0"
               data-selected="true"
               role="option"
               type="button"
@@ -331,7 +331,7 @@ exports[`supports multi-seat contests allows a second candidate to be selected w
             <button
               aria-label="Name 1, Party 1."
               class="c10"
-              data-id="name-1"
+              data-choice="name-1"
               data-selected="false"
               role="option"
               type="button"
@@ -353,7 +353,7 @@ exports[`supports multi-seat contests allows a second candidate to be selected w
             <button
               aria-label="Name 2, Party 0."
               class="c10"
-              data-id="name-2"
+              data-choice="name-2"
               data-selected="false"
               role="option"
               type="button"
@@ -641,7 +641,7 @@ exports[`supports single-seat contest allows any candidate to be selected when n
             <button
               aria-label="Name 0, Party 0."
               class="c8"
-              data-id="name-0"
+              data-choice="name-0"
               data-selected="false"
               role="option"
               type="button"
@@ -663,7 +663,7 @@ exports[`supports single-seat contest allows any candidate to be selected when n
             <button
               aria-label="Name 1, Party 1."
               class="c8"
-              data-id="name-1"
+              data-choice="name-1"
               data-selected="false"
               role="option"
               type="button"
@@ -685,7 +685,7 @@ exports[`supports single-seat contest allows any candidate to be selected when n
             <button
               aria-label="Name 2, Party 0."
               class="c8"
-              data-id="name-2"
+              data-choice="name-2"
               data-selected="false"
               role="option"
               type="button"
@@ -1021,7 +1021,7 @@ exports[`supports single-seat contest doesn't allow other candidates to be selec
             <button
               aria-label="Name 0, Party 0."
               class="c8"
-              data-id="name-0"
+              data-choice="name-0"
               data-selected="true"
               role="option"
               type="button"
@@ -1043,7 +1043,7 @@ exports[`supports single-seat contest doesn't allow other candidates to be selec
             <button
               aria-label="Name 1, Party 1."
               class="c10"
-              data-id="name-1"
+              data-choice="name-1"
               data-selected="false"
               role="option"
               type="button"
@@ -1065,7 +1065,7 @@ exports[`supports single-seat contest doesn't allow other candidates to be selec
             <button
               aria-label="Name 2, Party 0."
               class="c10"
-              data-id="name-2"
+              data-choice="name-2"
               data-selected="false"
               role="option"
               type="button"
@@ -1355,7 +1355,7 @@ exports[`supports write-in candidates displays warning if write-in candidate nam
             <button
               aria-label="Name 0, Party 0."
               class="c8"
-              data-id="name-0"
+              data-choice="name-0"
               data-selected="false"
               role="option"
               type="button"
@@ -1377,7 +1377,7 @@ exports[`supports write-in candidates displays warning if write-in candidate nam
             <button
               aria-label="Name 1, Party 1."
               class="c8"
-              data-id="name-1"
+              data-choice="name-1"
               data-selected="false"
               role="option"
               type="button"
@@ -1399,7 +1399,7 @@ exports[`supports write-in candidates displays warning if write-in candidate nam
             <button
               aria-label="Name 2, Party 0."
               class="c8"
-              data-id="name-2"
+              data-choice="name-2"
               data-selected="false"
               role="option"
               type="button"
@@ -1420,6 +1420,7 @@ exports[`supports write-in candidates displays warning if write-in candidate nam
             </button>
             <button
               class="c8"
+              data-choice="write-in"
               data-selected="false"
               role="option"
               type="button"

--- a/src/components/__snapshots__/ChoiceButton.test.tsx.snap
+++ b/src/components/__snapshots__/ChoiceButton.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`renders ChoiceButton 1`] = `
 
 <button
   class="c0"
+  data-choice="foo"
   data-selected="false"
   role="option"
   type="button"

--- a/src/components/__snapshots__/ChoiceButton.test.tsx.snap
+++ b/src/components/__snapshots__/ChoiceButton.test.tsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders ChoiceButton 1`] = `
+.c0 {
+  position: relative;
+  border-radius: 0.125rem;
+  box-shadow: 0 0.125rem 0.125rem 0 rgba(0,0,0,0.14), 0 0.1875rem 0.0625rem -0.125rem rgba(0,0,0,0.12), 0 0.0625rem 0.3125rem 0 rgba(0,0,0,0.2);
+  background: #FFFFFF;
+  cursor: pointer;
+  padding: 0.5rem 0.5rem 0.5rem 4rem;
+  text-align: left;
+  -webkit-transition: background 0.25s,color 0.25s;
+  transition: background 0.25s,color 0.25s;
+}
+
+.c0::before {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  border-right: 1px solid;
+  border-color: rgb(211,211,211);
+  border-radius: 0.125rem 0 0 0.125rem;
+  background: #FFFFFF;
+  width: 3rem;
+  text-align: center;
+  color: #028099;
+  font-size: 2rem;
+  font-weight: 700;
+  content: '';
+}
+
+@media (min-width:480px) {
+  .c0 {
+    padding: 1rem 1rem 1rem 4rem;
+  }
+}
+
+<button
+  class="c0"
+  data-selected="false"
+  role="option"
+  type="button"
+>
+  foo
+</button>
+`;

--- a/src/components/__snapshots__/YesNoContest.test.tsx.snap
+++ b/src/components/__snapshots__/YesNoContest.test.tsx.snap
@@ -296,8 +296,8 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
       >
         <button
           class="c10"
+          data-choice="yes"
           data-selected="false"
-          data-vote="yes"
           role="option"
           type="button"
         >
@@ -314,8 +314,8 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
         </button>
         <button
           class="c10"
+          data-choice="no"
           data-selected="false"
-          data-vote="no"
           role="option"
           type="button"
         >
@@ -680,8 +680,8 @@ exports[`supports yes/no contest displays warning when attempting to change vote
       >
         <button
           class="c10"
+          data-choice="yes"
           data-selected="true"
-          data-vote="yes"
           role="option"
           type="button"
         >
@@ -698,8 +698,8 @@ exports[`supports yes/no contest displays warning when attempting to change vote
         </button>
         <button
           class="c12"
+          data-choice="no"
           data-selected="false"
-          data-vote="no"
           role="option"
           type="button"
         >

--- a/src/lib/gamepad.test.tsx
+++ b/src/lib/gamepad.test.tsx
@@ -68,29 +68,29 @@ it('gamepad controls work', async () => {
 
   // Test navigation by gamepad
   handleGamepadButtonDown('DPadDown')
-  expect(getActiveElement().dataset.id).toEqual(contest0candidate0.id)
+  expect(getActiveElement().dataset.choice).toEqual(contest0candidate0.id)
   handleGamepadButtonDown('DPadDown')
-  expect(getActiveElement().dataset.id).toEqual(contest0candidate1.id)
+  expect(getActiveElement().dataset.choice).toEqual(contest0candidate1.id)
   handleGamepadButtonDown('DPadUp')
-  expect(getActiveElement().dataset.id).toEqual(contest0candidate0.id)
+  expect(getActiveElement().dataset.choice).toEqual(contest0candidate0.id)
 
   // test the edge case of rolling over
   handleGamepadButtonDown('DPadUp')
   expect(document.activeElement!.textContent).toEqual('Settings')
   handleGamepadButtonDown('DPadDown')
-  expect(getActiveElement().dataset.id).toEqual(contest0candidate0.id)
+  expect(getActiveElement().dataset.choice).toEqual(contest0candidate0.id)
 
   handleGamepadButtonDown('DPadRight')
   advanceTimers()
   // go up first without focus, then down once, should be same as down once.
   handleGamepadButtonDown('DPadUp')
   handleGamepadButtonDown('DPadDown')
-  expect(getActiveElement().dataset.id).toEqual(contest1candidate0.id)
+  expect(getActiveElement().dataset.choice).toEqual(contest1candidate0.id)
   handleGamepadButtonDown('DPadLeft')
   advanceTimers()
   // B is same as down
   handleGamepadButtonDown('B')
-  expect(getActiveElement().dataset.id).toEqual(contest0candidate0.id)
+  expect(getActiveElement().dataset.choice).toEqual(contest0candidate0.id)
 
   // select and unselect
   handleGamepadButtonDown('A')

--- a/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -72,6 +72,18 @@ exports[`Renders ContestPage 1`] = `
   margin: 0.25rem;
 }
 
+.c11 {
+  border: none;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  background: rgb(211,211,211);
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  line-height: 1.25;
+  color: black;
+  touch-action: manipulation;
+}
+
 .c8 {
   position: relative;
   border-radius: 0.125rem;
@@ -111,18 +123,6 @@ exports[`Renders ContestPage 1`] = `
   font-size: 2rem;
   font-weight: 700;
   content: '';
-}
-
-.c11 {
-  border: none;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  background: rgb(211,211,211);
-  cursor: pointer;
-  padding: 0.75rem 1rem;
-  line-height: 1.25;
-  color: black;
-  touch-action: manipulation;
 }
 
 .c0 {

--- a/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`Renders ContestPage 1`] = `
             <button
               aria-label="Joseph Barchi and Joseph Hallaren, Federalist."
               class="c8"
-              data-id="barchi-hallaren"
+              data-choice="barchi-hallaren"
               data-selected="false"
               role="option"
               type="button"
@@ -425,7 +425,7 @@ exports[`Renders ContestPage 1`] = `
             <button
               aria-label="Adam Cramer and Greg Vuocolo, People's."
               class="c8"
-              data-id="cramer-vuocolo"
+              data-choice="cramer-vuocolo"
               data-selected="false"
               role="option"
               type="button"
@@ -447,7 +447,7 @@ exports[`Renders ContestPage 1`] = `
             <button
               aria-label="Daniel Court and Amy Blumhardt, Liberty."
               class="c8"
-              data-id="court-blumhardt"
+              data-choice="court-blumhardt"
               data-selected="false"
               role="option"
               type="button"
@@ -469,7 +469,7 @@ exports[`Renders ContestPage 1`] = `
             <button
               aria-label="Alvin Boone and James Lian, Constitution."
               class="c8"
-              data-id="boone-lian"
+              data-choice="boone-lian"
               data-selected="false"
               role="option"
               type="button"
@@ -491,7 +491,7 @@ exports[`Renders ContestPage 1`] = `
             <button
               aria-label="Ashley Hildebrand-McDougall and James Garritty, Whig."
               class="c8"
-              data-id="hildebrand-garritty"
+              data-choice="hildebrand-garritty"
               data-selected="false"
               role="option"
               type="button"
@@ -513,7 +513,7 @@ exports[`Renders ContestPage 1`] = `
             <button
               aria-label="Martin Patterson and Clay Lariviere, Labor."
               class="c8"
-              data-id="patterson-lariviere"
+              data-choice="patterson-lariviere"
               data-selected="false"
               role="option"
               type="button"


### PR DESCRIPTION

The more I dig into touch events, the more I think the right thing is to use pointer events instead of click events. Here are the arguments:

* Pointer events are specifically designed to handle both mouse and touch with one type of event: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events . With our current approach -- the click event simulation -- there's no clear spec on what touches qualify as clicks. The difference in behavior we've seen between Chrome on Mac and Linux doesn't appear to be out of spec, it's just a different implementation choice. It's not an OS thing either, since Firefox behaves in our preferred way on Linux, unlike Chrome.

* With click simulation, even when it's the kind we like (e.g. Chrome on Mac), the click isn't issued until the finger is lifted, on `PointerUp`. That doesn't feel nearly as responsive as taking action on `PointerDown`. Try the `PointerDown` behavior with a touchscreen... it feels *wonderfully* responsive. I wonder if that's one reason why we've seen some testers hold their finger down longer, because they're not seeing an immediate reaction on touch.

* I'm not seeing any unexpected behavior with this approach. You can hold your finger as long as you want, a second `PointerDown` event isn't issued. You have to lift your finger and retouch... which would be a second click anyways in our current model. No timeouts, no special handling. It just works right, as best as I can tell.

* looks like we can change our tests to use `fireEvent.pointerDown` and all works well. See the one example in this PR.
