### PR TITLE
test(eslint): remove reference to undefined rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,5 @@ module.exports = {
     strict: 0,
     '@typescript-eslint/explicit-function-return-type': 'off', // Want to use it, but it requires return types for all built-in React lifecycle methods.
     '@typescript-eslint/no-non-null-assertion': 'off',
-    '@typescript-eslint/no-null-keyword': 'on',
   },
 }


### PR DESCRIPTION
As discussed at https://github.com/typescript-eslint/typescript-eslint/issues/676, there's no such rule as `@typescript-eslint/no-null-keyword` and no plans to add one.
