### PR TITLE
Landscape Layout fixes

### DIFF
--- a/src/AppMarkVoterCardInvalid.test.tsx
+++ b/src/AppMarkVoterCardInvalid.test.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
 })
 
 const idleScreenCopy =
-  'This voting station has been inactive for more than one minute.'
+  'This voting station has been inactive for more than 5 minutes.'
 
 describe('Mark Card Void when voter is idle too long', () => {
   it('Display expired card if card marked as voided', async () => {
@@ -59,7 +59,7 @@ describe('Mark Card Void when voter is idle too long', () => {
     getByText(idleScreenCopy)
 
     // User action removes Idle Screen
-    fireEvent.click(getByText('Touch the screen to go back to the ballot.'))
+    fireEvent.click(getByText('Yes, I’m still voting.'))
     fireEvent.mouseDown(document)
     advanceTimers()
     expect(queryByText(idleScreenCopy)).toBeFalsy()
@@ -71,10 +71,11 @@ describe('Mark Card Void when voter is idle too long', () => {
     getByText(idleScreenCopy)
 
     // Countdown works
-    advanceTimers(1)
-    getByText(`${IDLE_RESET_TIMEOUT_SECONDS - 1} seconds`)
+    const secondsRemaining = 20
+    advanceTimers(IDLE_RESET_TIMEOUT_SECONDS - secondsRemaining)
+    getByText(`${secondsRemaining} seconds`)
 
-    advanceTimers(IDLE_RESET_TIMEOUT_SECONDS - 1)
+    advanceTimers(secondsRemaining)
     advanceTimers()
     getByText('Clearing ballot')
 

--- a/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -540,12 +540,6 @@ exports[`Single Seat Contest 1`] = `
   }
 }
 
-@media print {
-  .c2 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c4 {
     line-height: 1.3;
@@ -574,12 +568,6 @@ exports[`Single Seat Contest 1`] = `
 
 @media print {
   .c1 {
-    display: block;
-  }
-}
-
-@media print {
-  .c13 {
     display: none;
   }
 }

--- a/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
@@ -540,12 +540,6 @@ exports[`Single Seat Contest 1`] = `
   }
 }
 
-@media print {
-  .c2 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c4 {
     line-height: 1.3;
@@ -574,12 +568,6 @@ exports[`Single Seat Contest 1`] = `
 
 @media print {
   .c1 {
-    display: block;
-  }
-}
-
-@media print {
-  .c13 {
     display: none;
   }
 }

--- a/src/__snapshots__/AppContestWriteIn.test.tsx.snap
+++ b/src/__snapshots__/AppContestWriteIn.test.tsx.snap
@@ -492,12 +492,6 @@ exports[`Single Seat Contest with Write In 1`] = `
   }
 }
 
-@media print {
-  .c2 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c4 {
     line-height: 1.3;
@@ -526,12 +520,6 @@ exports[`Single Seat Contest with Write In 1`] = `
 
 @media print {
   .c1 {
-    display: block;
-  }
-}
-
-@media print {
-  .c12 {
     display: none;
   }
 }

--- a/src/components/ButtonBar.tsx
+++ b/src/components/ButtonBar.tsx
@@ -24,9 +24,6 @@ const ButtonBar = styled('nav')`
       min-width: 33.333%;
     }
   }
-  @media print {
-    display: none;
-  }
 `
 
 export default ButtonBar

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -19,9 +19,6 @@ const Main = styled('main')<Props>`
   @media (min-width: 480px) {
     padding: ${({ padded = false }) => (padded ? '2rem' : undefined)};
   }
-  @media print {
-    display: none;
-  }
 `
 
 interface ChildProps {
@@ -38,10 +35,6 @@ export const MainChild = styled('div')<ChildProps>`
     centerHorizontal = center,
   }) => `${centerVertical ? 'auto' : '0'} ${centerHorizontal ? 'auto' : '0'}`};
   max-width: ${({ maxWidth = true }) => (maxWidth ? '35rem' : undefined)};
-  @media print {
-    margin: 0;
-    max-width: 100%;
-  }
 `
 
 export default Main

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -29,7 +29,6 @@ interface ChildProps {
   centerVertical?: boolean
   centerHorizontal?: boolean
   maxWidth?: boolean
-  padded?: boolean
 }
 
 export const MainChild = styled('div')<ChildProps>`

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -16,7 +16,7 @@ const Screen = styled.div<Props>`
     flex: ${({ voterMode = true }) => (voterMode ? '2' : '3')};
   }
   @media print {
-    display: block;
+    display: none;
   }
 `
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,9 +15,6 @@ const StyledSidebar = styled.nav`
   flex-direction: column;
   background-color: #333333;
   color: #ffffff;
-  @media print {
-    display: none;
-  }
 `
 
 const Header = styled.div`

--- a/src/components/__snapshots__/ButtonBar.test.tsx.snap
+++ b/src/components/__snapshots__/ButtonBar.test.tsx.snap
@@ -45,12 +45,6 @@ exports[`renders ButtonBar 1`] = `
   }
 }
 
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
 <nav
   class="c0"
 >

--- a/src/components/__snapshots__/CandidateContest.test.tsx.snap
+++ b/src/components/__snapshots__/CandidateContest.test.tsx.snap
@@ -242,12 +242,6 @@ exports[`supports multi-seat contests allows a second candidate to be selected w
   }
 }
 
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c2 {
     line-height: 1.3;
@@ -582,12 +576,6 @@ exports[`supports single-seat contest allows any candidate to be selected when n
 @media (min-width:480px) {
   .c8 {
     padding: 1rem 1rem 1rem 4rem;
-  }
-}
-
-@media print {
-  .c0 {
-    display: none;
   }
 }
 
@@ -976,12 +964,6 @@ exports[`supports single-seat contest doesn't allow other candidates to be selec
   }
 }
 
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c2 {
     line-height: 1.3;
@@ -1316,12 +1298,6 @@ exports[`supports write-in candidates displays warning if write-in candidate nam
 @media (min-width:480px) {
   .c8 {
     padding: 1rem 1rem 1rem 4rem;
-  }
-}
-
-@media print {
-  .c0 {
-    display: none;
   }
 }
 

--- a/src/components/__snapshots__/Main.test.tsx.snap
+++ b/src/components/__snapshots__/Main.test.tsx.snap
@@ -17,19 +17,6 @@ exports[`renders Main with centered content 1`] = `
   max-width: 35rem;
 }
 
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
-@media print {
-  .c1 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 <main
   class="c0"
 >
@@ -58,19 +45,6 @@ exports[`renders Main with child 1`] = `
   max-width: 35rem;
 }
 
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
-@media print {
-  .c1 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 <main
   class="c0"
 >
@@ -96,19 +70,6 @@ exports[`renders Main with not centered content 1`] = `
 .c1 {
   margin: 0 0;
   max-width: 35rem;
-}
-
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
-@media print {
-  .c1 {
-    margin: 0;
-    max-width: 100%;
-  }
 }
 
 <main
@@ -143,19 +104,6 @@ exports[`renders Main with padding 1`] = `
 @media (min-width:480px) {
   .c0 {
     padding: 2rem;
-  }
-}
-
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
-@media print {
-  .c1 {
-    margin: 0;
-    max-width: 100%;
   }
 }
 

--- a/src/components/__snapshots__/YesNoContest.test.tsx.snap
+++ b/src/components/__snapshots__/YesNoContest.test.tsx.snap
@@ -205,12 +205,6 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
   }
 }
 
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c2 {
     line-height: 1.3;
@@ -597,12 +591,6 @@ exports[`supports yes/no contest displays warning when attempting to change vote
 @media (min-width:480px) {
   .c10 {
     padding: 1rem 1rem 1rem 4rem;
-  }
-}
-
-@media print {
-  .c0 {
-    display: none;
   }
 }
 

--- a/src/pages/ClerkScreen.test.tsx
+++ b/src/pages/ClerkScreen.test.tsx
@@ -40,14 +40,14 @@ it('renders ClerkScreen', async () => {
   fireEvent.click(getByText('Center Springfield'))
 
   // Back All Decks
-  fireEvent.click(getByText('Back to All Decks'))
+  fireEvent.click(getByText('Back to Precincts List'))
 
   // Single Precinct
   fireEvent.click(getByText('North Springfield'))
-  fireEvent.click(getByText('Dashboard'))
+  fireEvent.click(getByText('Back to Admin Dashboard'))
 
   // All Precincts
   fireEvent.click(getByText('View Test Ballot Decks'))
   fireEvent.click(getByText('All Precincts'))
-  fireEvent.click(getByText('Dashboard'))
+  fireEvent.click(getByText('Back to Admin Dashboard'))
 })

--- a/src/pages/IdlePage.tsx
+++ b/src/pages/IdlePage.tsx
@@ -5,8 +5,12 @@ import React, {
   PointerEventHandler,
 } from 'react'
 import pluralize from 'pluralize'
-
 import useInterval from 'use-interval'
+
+import {
+  IDLE_RESET_TIMEOUT_SECONDS,
+  IDLE_TIMEOUT_SECONDS,
+} from '../config/globals'
 
 import BallotContext from '../contexts/ballotContext'
 
@@ -14,17 +18,14 @@ import Button from '../components/Button'
 import Main, { MainChild } from '../components/Main'
 import Prose from '../components/Prose'
 import Loading from '../components/Loading'
-import { IDLE_RESET_TIMEOUT_SECONDS } from '../config/globals'
+import Screen from '../components/Screen'
 
 const timeoutSeconds = IDLE_RESET_TIMEOUT_SECONDS
 
 const IdlePage = () => {
-  const { election, markVoterCardVoided, resetBallot } = useContext(
-    BallotContext
-  )
+  const { markVoterCardVoided, resetBallot } = useContext(BallotContext)
   const [countdown, setCountdown] = useState(timeoutSeconds)
   const [isLoading, setIsLoading] = useState(false)
-  const { title } = election
 
   const onPress: PointerEventHandler = () => {}
 
@@ -42,28 +43,32 @@ const IdlePage = () => {
   }, 1000)
 
   return (
-    <Main>
-      <MainChild center>
-        {isLoading ? (
-          <Loading>Clearing ballot</Loading>
-        ) : (
-          <Prose textCenter>
-            <h1 aria-label={`${title}.`}>{title}</h1>
-            <hr />
-            <p>
-              This voting station has been inactive for more than one minute.
-            </p>
-            <p>
-              To protect your privacy, this ballot will be cleared in{' '}
-              <strong>{pluralize('second', countdown, true)}</strong>.
-            </p>
-            <Button primary onPress={onPress}>
-              Touch the screen to go back to the ballot.
-            </Button>
-          </Prose>
-        )}
-      </MainChild>
-    </Main>
+    <Screen>
+      <Main>
+        <MainChild center>
+          {isLoading ? (
+            <Loading>Clearing ballot</Loading>
+          ) : (
+            <Prose textCenter>
+              <h1 aria-label="Are you still voting?">Are you still voting?</h1>
+              <p>
+                This voting station has been inactive for more than{' '}
+                {pluralize('minute', IDLE_TIMEOUT_SECONDS / 60, true)}.
+              </p>
+              {countdown <= timeoutSeconds / 2 && (
+                <p>
+                  To protect your privacy, this ballot will be cleared in{' '}
+                  <strong>{pluralize('second', countdown, true)}</strong>.
+                </p>
+              )}
+              <Button primary onPress={onPress}>
+                Yes, I’m still voting.
+              </Button>
+            </Prose>
+          )}
+        </MainChild>
+      </Main>
+    </Screen>
   )
 }
 

--- a/src/pages/TestBallotDeckScreen.tsx
+++ b/src/pages/TestBallotDeckScreen.tsx
@@ -1,4 +1,5 @@
 import React, { PointerEventHandler, useState } from 'react'
+import pluralize from 'pluralize'
 
 import {
   AppModeNames,
@@ -14,6 +15,7 @@ import Main, { MainChild } from '../components/Main'
 import PrintedBallot from '../components/PrintedBallot'
 import Prose from '../components/Prose'
 import Sidebar from '../components/Sidebar'
+import Screen from '../components/Screen'
 
 interface Ballot {
   ballotId?: string
@@ -123,86 +125,84 @@ const TestBallotDeckScreen = ({
 
   return (
     <React.Fragment>
-      {ballots.length ? (
-        <React.Fragment>
-          <Main>
-            <MainChild maxWidth={false}>
+      <Screen flexDirection="row-reverse" voterMode={false}>
+        <Main padded>
+          <MainChild maxWidth={false}>
+            {ballots.length ? (
               <Prose className="no-print">
-                <h1>Test Ballots Deck for {precinct.name}</h1>
+                <h1>Test Ballot Decks</h1>
                 <p>
-                  <Button primary onPress={window.print}>
+                  Deck containing{' '}
+                  <strong>{pluralize('ballot', ballots.length, true)}</strong>{' '}
+                  for {precinct.name}.
+                </p>
+                <p>
+                  <Button big primary onPress={window.print}>
                     Print {ballots.length} ballots
                   </Button>
                 </p>
                 <p>
                   <Button small onPress={resetDeck}>
-                    Back to All Decks
+                    Back to Precincts List
                   </Button>
                 </p>
               </Prose>
-            </MainChild>
-          </Main>
-          {ballots.map((ballot, i) => {
-            const ballotId = `temp-ballot-id-${i}`
-            return (
-              <PrintedBallot
-                key={ballotId}
-                ballotStyleId={ballot.ballotStyleId}
-                election={election}
-                isLiveMode={isLiveMode}
-                precinctId={ballot.precinctId}
-                votes={ballot.votes}
-              />
-            )
-          })}
-        </React.Fragment>
-      ) : (
-        <React.Fragment>
-          <Main>
-            <MainChild maxWidth={false}>
-              <Prose>
-                <h1>Test Ballot Decks</h1>
+            ) : (
+              <React.Fragment>
+                <Prose>
+                  <h1>Test Ballot Decks</h1>
+                  <p>Select desired precinct.</p>
+                </Prose>
                 <p>
-                  Select desired precinct for <strong>{election.title}</strong>.
-                </p>
-              </Prose>
-              <p>
-                <Button
-                  data-id=""
-                  data-name="All Precincts"
-                  fullWidth
-                  key="all-precincts"
-                  onPress={selectPrecinct}
-                >
-                  <strong>All Precincts</strong>
-                </Button>
-              </p>
-              <ButtonList>
-                {election.precincts.map(p => (
                   <Button
-                    data-id={p.id}
-                    data-name={p.name}
+                    data-id=""
+                    data-name="All Precincts"
                     fullWidth
-                    key={p.id}
+                    key="all-precincts"
                     onPress={selectPrecinct}
                   >
-                    {p.name}
+                    <strong>All Precincts</strong>
                   </Button>
-                ))}
-              </ButtonList>
-            </MainChild>
-          </Main>
-        </React.Fragment>
-      )}
-      <Sidebar
-        appName={appName}
-        title="Election Admin Actions"
-        footer={election && <ElectionInfo election={election} horizontal />}
-      >
-        <Button small onPress={hideTestDeck}>
-          Dashboard
-        </Button>
-      </Sidebar>
+                </p>
+                <ButtonList>
+                  {election.precincts.map(p => (
+                    <Button
+                      data-id={p.id}
+                      data-name={p.name}
+                      fullWidth
+                      key={p.id}
+                      onPress={selectPrecinct}
+                    >
+                      {p.name}
+                    </Button>
+                  ))}
+                </ButtonList>
+              </React.Fragment>
+            )}
+          </MainChild>
+        </Main>
+        <Sidebar
+          appName={appName}
+          title="Election Admin Actions"
+          footer={election && <ElectionInfo election={election} horizontal />}
+        >
+          <Button small onPress={hideTestDeck}>
+            Back to Admin Dashboard
+          </Button>
+        </Sidebar>
+      </Screen>
+      {ballots.length &&
+        ballots.map((ballot, i) => (
+          <PrintedBallot
+            // eslint-disable-next-line react/no-array-index-key
+            key={`ballot-${i}`}
+            ballotStyleId={ballot.ballotStyleId}
+            election={election}
+            isLiveMode={isLiveMode}
+            precinctId={ballot.precinctId}
+            votes={ballot.votes}
+          />
+        ))}
     </React.Fragment>
   )
 }

--- a/src/pages/__snapshots__/CastBallotPage.test.tsx.snap
+++ b/src/pages/__snapshots__/CastBallotPage.test.tsx.snap
@@ -113,19 +113,6 @@ exports[`renders CastBallotPage 1`] = `
   text-align: left;
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -134,7 +121,7 @@ exports[`renders CastBallotPage 1`] = `
 
 @media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 

--- a/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -475,12 +475,6 @@ exports[`Renders ContestPage 1`] = `
   }
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -509,12 +503,6 @@ exports[`Renders ContestPage 1`] = `
 
 @media print {
   .c0 {
-    display: block;
-  }
-}
-
-@media print {
-  .c11 {
     display: none;
   }
 }

--- a/src/pages/__snapshots__/NotFoundPage.test.tsx.snap
+++ b/src/pages/__snapshots__/NotFoundPage.test.tsx.snap
@@ -118,19 +118,6 @@ exports[`renders NotFoundPage 1`] = `
   flex: 2;
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -139,7 +126,7 @@ exports[`renders NotFoundPage 1`] = `
 
 @media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 

--- a/src/pages/__snapshots__/PrintPage.test.tsx.snap
+++ b/src/pages/__snapshots__/PrintPage.test.tsx.snap
@@ -189,19 +189,6 @@ exports[`renders PrintPage with votes 1`] = `
   flex: 2;
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -216,7 +203,7 @@ exports[`renders PrintPage with votes 1`] = `
 
 @media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 
@@ -442,19 +429,6 @@ exports[`renders PrintPage without votes 1`] = `
   flex: 2;
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -469,7 +443,7 @@ exports[`renders PrintPage without votes 1`] = `
 
 @media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 
@@ -695,19 +669,6 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
   flex: 2;
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -722,7 +683,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
 
 @media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 
@@ -948,19 +909,6 @@ exports[`renders PrintPage without votes and no seal 1`] = `
   flex: 2;
 }
 
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
 @media (min-width:480px) {
   .c3 {
     line-height: 1.3;
@@ -975,7 +923,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
 
 @media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 

--- a/src/pages/__snapshots__/StartPage.test.tsx.snap
+++ b/src/pages/__snapshots__/StartPage.test.tsx.snap
@@ -459,27 +459,8 @@ exports[`renders StartPage 1`] = `
 }
 
 @media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
-@media print {
-  .c4 {
-    display: none;
-  }
-}
-
-@media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 
@@ -1113,27 +1094,8 @@ exports[`renders StartPage with inline SVG 1`] = `
 }
 
 @media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
-@media print {
-  .c4 {
-    display: none;
-  }
-}
-
-@media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 
@@ -1910,27 +1872,8 @@ exports[`renders StartPage with no seal 1`] = `
 }
 
 @media print {
-  .c1 {
-    display: none;
-  }
-}
-
-@media print {
-  .c2 {
-    margin: 0;
-    max-width: 100%;
-  }
-}
-
-@media print {
-  .c4 {
-    display: none;
-  }
-}
-
-@media print {
   .c0 {
-    display: block;
+    display: none;
   }
 }
 


### PR DESCRIPTION
Started looking for printing issues and found a couple landscape layout fixes to make. Also made the Idle screen more pleasant.

The printing-related fixes are a culmination of the following layout strategy:

`Screen` is the parent of all screen-visible items, it has styles hide when printing. The only children of `Screen` are `Main`, `Sidebar`, `Modal`.

When a screen has content to print, wrap in `Screen` in `<React.Fragment>` and add content to print as siblings to `Screen`. Printable components are `display: none` by default and are only visible when printing.

You'll see some version of the following in all `src/page/*` files:

```jsx
<React.Fragment>
  <Screen>
    <Main>
      <MainChild>
        // main page content here
      </MainChild>
    </Main>
    <Sidebar />
    <Modal />
    <Modal />
  </Screen>
  {ballots.map(() => <PrintedBallot />)}
  {reports.map(() => <PrintedReport />)}
</React.Fragment>
```