### PR TITLE
refactor: clarify the tally report types

### DIFF
--- a/src/components/PrecinctTallyReport.tsx
+++ b/src/components/PrecinctTallyReport.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Election, Tally, Precinct } from '../config/types'
+import {
+  Election,
+  Tally,
+  Precinct,
+  CandidateVoteTally,
+  YesNoVoteTally,
+} from '../config/types'
 
 import numberWithCommas from '../utils/numberWithCommas'
 
@@ -56,14 +62,14 @@ const PrecinctTallyReport = ({
   return (
     <Report>
       <h1>
-        <NoWrap>{precinct.name}</NoWrap> <NoWrap>{election.title}</NoWrap>{' '}
+        <NoWrap>{precinct.name}</NoWrap> <NoWrap>{election.title}</NoWrap>
         <NoWrap>Tally Report</NoWrap>
       </h1>
       <p>
         This report should be <strong>{reportPurpose}</strong>.
       </p>
       <p>
-        {isPollsOpen ? 'Polls Closed' : 'Polls Opened'} and report printed at:{' '}
+        {isPollsOpen ? 'Polls Closed' : 'Polls Opened'} and report printed at:
         <strong>{currentDateTime}</strong>
       </p>
       <p>
@@ -88,9 +94,10 @@ const PrecinctTallyReport = ({
                           <td>{candidate.name}</td>
                           <TD narrow textAlign="right">
                             {isContestInPrecinct
-                              ? numberWithCommas(tally[contestIndex][
-                                  candidateIndex
-                                ] as number)
+                              ? numberWithCommas(
+                                  (tally[contestIndex] as CandidateVoteTally)
+                                    .candidates[candidateIndex]
+                                )
                               : 'X'}
                           </TD>
                         </tr>
@@ -102,7 +109,9 @@ const PrecinctTallyReport = ({
                         <td>Yes</td>
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
-                            ? numberWithCommas(tally[contestIndex][0] as number)
+                            ? numberWithCommas(
+                                (tally[contestIndex] as YesNoVoteTally).yes
+                              )
                             : 'X'}
                         </TD>
                       </tr>
@@ -110,7 +119,9 @@ const PrecinctTallyReport = ({
                         <td>No</td>
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
-                            ? numberWithCommas(tally[contestIndex][1] as number)
+                            ? numberWithCommas(
+                                (tally[contestIndex] as YesNoVoteTally).no
+                              )
                             : 'X'}
                         </TD>
                       </tr>

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -129,8 +129,14 @@ export interface WriteInCandidateTally {
   tally: number
 }
 export type TallyCount = number
-export type CandidateVoteTally = (TallyCount | WriteInCandidateTally)[]
-export type YesNoVoteTally = TallyCount[]
+export interface CandidateVoteTally {
+  candidates: TallyCount[]
+  writeIns: WriteInCandidateTally[]
+}
+export interface YesNoVoteTally {
+  yes: TallyCount
+  no: TallyCount
+}
 export type Tally = (CandidateVoteTally | YesNoVoteTally)[]
 
 // Ballot

--- a/src/utils/election.ts
+++ b/src/utils/election.ts
@@ -1,3 +1,4 @@
+import { Contest } from '@votingworks/ballot-encoder'
 import { BallotStyle, Election, Tally } from '../config/types'
 
 export const getContests = ({
@@ -47,11 +48,17 @@ export const getZeroTally = (election: Election): Tally =>
   election.contests.map(contest => {
     /* istanbul ignore else */
     if (contest.type === 'yesno') {
-      return [0, 0]
+      return { yes: 0, no: 0 }
     } else if (contest.type === 'candidate') {
-      return contest.candidates.map(() => 0)
+      return {
+        candidates: contest.candidates.map(() => 0),
+        writeIns: [],
+      }
     } else {
-      return []
+      // `as Contest` is needed because TS knows 'yesno' and 'candidate' are the
+      // only valid values and so infers `contest` is type `never`, and we want
+      // to fail loudly in this situation.
+      throw new Error(`unexpected contest type: ${(contest as Contest).type}`)
     }
   })
 


### PR DESCRIPTION
This changes the types for the candidate and yesno tallies from arrays into objects. For candidate contests, it splits the former single array that contained both write-ins and ballot candidates into separate properties on an object. For yesno contests, instead of a 2-element tuple we now have an object with "yes" and "no" properties.

I think this is simpler and requires less casting. It also adds a few assertions for situations which shouldn't happen but otherwise might silently fail.

