### PR TITLE
refactor: prepare printer for PDF printing

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@testing-library/cypress": "^5.0.1",
     "@testing-library/react": "^9.3.0",
     "@types/base64-js": "^1.2.5",
+    "@types/pdfmake": "^0.1.8",
     "@types/react-gamepad": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "^1.13.0",

--- a/src/pages/PollWorkerScreen.tsx
+++ b/src/pages/PollWorkerScreen.tsx
@@ -11,7 +11,7 @@ import Screen from '../components/Screen'
 import Text from '../components/Text'
 import Sidebar from '../components/Sidebar'
 import ElectionInfo from '../components/ElectionInfo'
-import { NullPrinter } from '../utils/printer'
+import { NullPrinter, PrintType } from '../utils/printer'
 import PollsReport from '../components/PollsReport'
 import PrecinctTallyReport from '../components/PrecinctTallyReport'
 
@@ -49,7 +49,7 @@ const PollWorkerScreen = ({
   const isPrintMode = !!appMode.isVxPrint
 
   const printReport = async () => {
-    await printer.print()
+    await printer.print({ type: PrintType.CurrentPage })
     togglePollsOpen()
     hideModal()
   }

--- a/src/pages/PrintOnlyScreen.tsx
+++ b/src/pages/PrintOnlyScreen.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import styled from 'styled-components'
 import { Election, MarkVoterCardFunction, VotesDict } from '../config/types'
-import { NullPrinter } from '../utils/printer'
+import { NullPrinter, PrintType } from '../utils/printer'
 import isEmptyObject from '../utils/isEmptyObject'
 
 import Prose from '../components/Prose'
@@ -54,7 +54,7 @@ const PrintOnlyScreen = ({
     const isUsed = await markVoterCardPrinted()
     /* istanbul ignore else */
     if (isUsed) {
-      await printer.print()
+      await printer.print({ type: PrintType.CurrentPage })
       updateTally()
       printerTimer.current = window.setTimeout(() => {
         updateIsPrinted(true)

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -9,6 +9,7 @@ import Prose from '../components/Prose'
 
 import BallotContext from '../contexts/ballotContext'
 import Screen from '../components/Screen'
+import { PrintType } from '../utils/printer'
 
 export const printerMessageTimeoutSeconds = 5
 
@@ -30,7 +31,7 @@ const PrintPage = () => {
     const isUsed = await markVoterCardPrinted()
     /* istanbul ignore else */
     if (isUsed) {
-      await printer.print()
+      await printer.print({ type: PrintType.CurrentPage })
       updateTally()
       printerTimer.current = window.setTimeout(() => {
         resetBallot()

--- a/src/utils/printer.test.ts
+++ b/src/utils/printer.test.ts
@@ -1,14 +1,15 @@
 import fetchMock from 'fetch-mock'
-import makePrinter, {
-  PrintMethod,
-  LocalPrinter,
-  RemotePrinter,
-  FallbackPrinters,
-  PrintStatus,
-  NullPrinter,
-} from './printer'
 import fakePrinter from '../../test/helpers/fakePrinter'
 import { mockOf } from '../../test/testUtils'
+import makePrinter, {
+  FallbackPrinters,
+  LocalPrinter,
+  NullPrinter,
+  PrintMethod,
+  PrintStatus,
+  PrintType,
+  RemotePrinter,
+} from './printer'
 
 const printMock = mockOf(window.print)
 
@@ -33,14 +34,35 @@ test('`makePrinter` throws when given an unknown method', () => {
 })
 
 describe('a local printer', () => {
-  it('is always ready', async () => {
-    expect(await makePrinter(PrintMethod.LocalOnly).isReady()).toBe(true)
+  it('can always print the current page', async () => {
+    expect(
+      await makePrinter(PrintMethod.LocalOnly).canPrint(PrintType.CurrentPage)
+    ).toBe(true)
+  })
+
+  it('cannot print anything else', async () => {
+    expect(
+      await makePrinter(PrintMethod.LocalOnly).canPrint(PrintType.HTMLDocument)
+    ).toBe(false)
+  })
+
+  it('fails when trying to print anything but the current page', async () => {
+    expect(
+      makePrinter(PrintMethod.LocalOnly).print({
+        type: PrintType.HTMLDocument,
+        html: '<strong>hello world</strong>',
+      })
+    ).rejects.toThrowError(
+      'LocalPrinter cannot handle print payload with type: HTMLDocument'
+    )
   })
 
   it('calls `window.print` when printing', async () => {
     printMock.mockReturnValueOnce(undefined)
 
-    await makePrinter(PrintMethod.LocalOnly).print()
+    await makePrinter(PrintMethod.LocalOnly).print({
+      type: PrintType.CurrentPage,
+    })
     expect(window.print).toHaveBeenCalled()
   })
 
@@ -48,56 +70,109 @@ describe('a local printer', () => {
     printMock.mockReturnValueOnce(undefined)
 
     const printer = makePrinter(PrintMethod.LocalOnly)
-    const job = await printer.print()
+    const job = await printer.print({ type: PrintType.CurrentPage })
 
     expect(await printer.getStatus(job)).toEqual(PrintStatus.Unknown)
   })
 })
 
 describe('a remote printer', () => {
-  it('is ready if it responds to a status check', async () => {
+  it('can print anything if it responds to a status check', async () => {
     fetchMock.get('/printer/status', { ok: true })
-    expect(await makePrinter(PrintMethod.RemoteOnly).isReady()).toBe(true)
+    expect(
+      await makePrinter(PrintMethod.RemoteOnly).canPrint(PrintType.CurrentPage)
+    ).toBe(true)
   })
 
-  it('is not ready if it fails to respond', async () => {
+  it('cannot print anything if it fails to respond', async () => {
     fetchMock.get('/printer/status', 504)
-    expect(await makePrinter(PrintMethod.RemoteOnly).isReady()).toBe(false)
+    expect(
+      await makePrinter(PrintMethod.RemoteOnly).canPrint(PrintType.CurrentPage)
+    ).toBe(false)
   })
 
-  it('is not ready if it responds but with a bad status', async () => {
+  it('cannot print if it responds but with a bad status', async () => {
     fetchMock.get('/printer/status', { ok: false })
-    expect(await makePrinter(PrintMethod.RemoteOnly).isReady()).toBe(false)
+    expect(
+      await makePrinter(PrintMethod.RemoteOnly).canPrint(PrintType.CurrentPage)
+    ).toBe(false)
   })
 
-  it('does not call `window.print` when printing', async () => {
+  it('does not call `window.print` when printing the current page', async () => {
     fetchMock.get('/printer/status', { ok: true })
-    fetchMock.post(
-      '/printer/jobs/new',
-      new Response(JSON.stringify({ id: 'job-id' }), { status: 201 })
-    )
+    fetchMock.post('/printer/jobs/new', {
+      body: JSON.stringify({ id: 'job-id' }),
+      status: 201,
+    })
 
-    await makePrinter(PrintMethod.RemoteOnly).print()
+    await makePrinter(PrintMethod.RemoteOnly).print({
+      type: PrintType.CurrentPage,
+    })
     expect(window.print).not.toHaveBeenCalled()
+  })
+
+  it('prints HTML documents', async () => {
+    fetchMock.get('/printer/status', { ok: true })
+    fetchMock.post('/printer/jobs/new', {
+      body: JSON.stringify({ id: 'job-id' }),
+      status: 201,
+    })
+
+    const job = await makePrinter(PrintMethod.RemoteOnly).print({
+      type: PrintType.HTMLDocument,
+      html: '<strong>hello world</strong>',
+    })
+    expect(window.print).not.toHaveBeenCalled()
+    expect(job.id).toEqual('job-id')
+  })
+
+  it('prints PDF documents', async () => {
+    fetchMock.get('/printer/status', { ok: true })
+    fetchMock.post('/printer/jobs/new', {
+      body: JSON.stringify({ id: 'job-id' }),
+      status: 201,
+    })
+
+    const job = await makePrinter(PrintMethod.RemoteOnly).print({
+      type: PrintType.PDFDocument,
+      pdf: Uint8Array.of(),
+    })
+    expect(window.print).not.toHaveBeenCalled()
+    expect(job.id).toEqual('job-id')
+  })
+
+  it('prints pdfmake documents', async () => {
+    fetchMock.get('/printer/status', { ok: true })
+    fetchMock.post('/printer/jobs/new', {
+      body: JSON.stringify({ id: 'job-id' }),
+      status: 201,
+    })
+
+    const job = await makePrinter(PrintMethod.RemoteOnly).print({
+      type: PrintType.PDFMakeDocument,
+      pdf: { content: [] },
+    })
+    expect(window.print).not.toHaveBeenCalled()
+    expect(job.id).toEqual('job-id')
   })
 
   it('refuses to print if it is not ready', async () => {
     fetchMock.get('/printer/status', { ok: false })
 
-    expect(makePrinter(PrintMethod.RemoteOnly).print()).rejects.toThrowError(
-      'unable to print: remote printer is not ready'
-    )
+    expect(
+      makePrinter(PrintMethod.RemoteOnly).print({ type: PrintType.CurrentPage })
+    ).rejects.toThrowError('unable to print: remote printer is not ready')
   })
 
   it('cannot get status of print (https://github.com/votingworks/module-print/issues/6)', async () => {
     fetchMock.get('/printer/status', { ok: true })
-    fetchMock.post(
-      '/printer/jobs/new',
-      new Response(JSON.stringify({ id: 'job-id' }), { status: 201 })
-    )
+    fetchMock.post('/printer/jobs/new', {
+      body: JSON.stringify({ id: 'job-id' }),
+      status: 201,
+    })
 
     const printer = makePrinter(PrintMethod.RemoteOnly)
-    const job = await printer.print()
+    const job = await printer.print({ type: PrintType.CurrentPage })
 
     expect(await printer.getStatus(job)).toEqual(PrintStatus.Unknown)
   })
@@ -108,41 +183,43 @@ describe('a fallback printer', () => {
     expect(() => new FallbackPrinters([])).toThrow()
   })
 
-  it('`isReady` returns true if any printer is ready', async () => {
+  it('can print if any printer can print', async () => {
     const printer = new FallbackPrinters([
       fakePrinter({
-        async isReady() {
+        async canPrint(): Promise<boolean> {
           return true
         },
       }),
     ])
 
-    expect(await printer.isReady()).toBe(true)
+    expect(await printer.canPrint(PrintType.CurrentPage)).toBe(true)
   })
 
-  it('`isReady` returns false if no printer is ready', async () => {
+  it('cannot print if no printer can print', async () => {
     const printer = new FallbackPrinters([fakePrinter()])
 
-    expect(await printer.isReady()).toBe(false)
+    expect(await printer.canPrint(PrintType.CurrentPage)).toBe(false)
   })
 
-  it('`print` prints from the first printer that is ready', async () => {
+  it('prints using the first printer that can print', async () => {
     const p1 = fakePrinter()
     const p2 = fakePrinter({
-      async isReady() {
+      async canPrint(): Promise<boolean> {
         return true
       },
     })
     const p3 = fakePrinter()
     const printer = new FallbackPrinters([p1, p2, p3])
 
-    expect((await printer.print()).owner).toBe(p2)
+    expect((await printer.print({ type: PrintType.CurrentPage })).owner).toBe(
+      p2
+    )
   })
 
-  it('`print` fails if no printers are ready to print', async () => {
+  it('fails to print if no printers can print', async () => {
     const printer = new FallbackPrinters([fakePrinter()])
 
-    expect(printer.print()).rejects.toThrowError(
+    expect(printer.print({ type: PrintType.CurrentPage })).rejects.toThrowError(
       'no printers were ready to print'
     )
   })
@@ -168,14 +245,16 @@ describe('a fallback printer', () => {
 })
 
 describe('a null printer', () => {
-  it('is always ready', async () => {
-    expect(await new NullPrinter().isReady()).toBe(true)
+  it('can always print', async () => {
+    expect(await new NullPrinter().canPrint(PrintType.CurrentPage)).toBe(true)
   })
 
   it('does not print to `window.print`', async () => {
     const printer = new NullPrinter()
 
-    expect((await printer.print()).owner).toBe(printer)
+    expect((await printer.print({ type: PrintType.CurrentPage })).owner).toBe(
+      printer
+    )
     expect(window.print).not.toHaveBeenCalled()
   })
 

--- a/test/helpers/fakePrinter.ts
+++ b/test/helpers/fakePrinter.ts
@@ -1,7 +1,7 @@
 import { PrintStatus, Printer } from '../../src/utils/printer'
 
 export default function fakePrinter({
-  isReady = async () => false,
+  canPrint: isReady = async () => false,
   getStatus = async () => PrintStatus.Unknown,
   print = async function(this: Printer) {
     return { id: '__mock', owner: this }
@@ -9,7 +9,7 @@ export default function fakePrinter({
   ...rest
 }: Partial<Printer> = {}): jest.Mocked<Printer> {
   return {
-    isReady: jest.fn(isReady),
+    canPrint: jest.fn(isReady),
     getStatus: jest.fn(getStatus),
     print: jest.fn(print),
     ...rest,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/pdfmake@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@types/pdfmake/-/pdfmake-0.1.8.tgz#ea01d912203381bc658757b33363390fa0d07cf0"
+  integrity sha512-Pbi9K99VfM3LLiKYSIe5JTM5f5KEZr+CslZcuDYzOsjq/6NOejoLoXcp+9C9um1c+2RpcgQymUHvFUEDPTAgig==
+
 "@types/pluralize@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.29.tgz#6ffa33ed1fc8813c469b859681d09707eb40d03c"


### PR DESCRIPTION
This doesn't change any behavior for now, but it adds the concept of a print job type. For now, the only print job type we're using is `CurrentPage` which will print the current page. In the future, we'll use the `PDFMakeDocument` type which `module-print` will accept but the fallback "local" printer won't. This allows us to determine whether we can print PDFs and, if not, fall back to printing using `CurrentPage` type.
