### PR TITLE
fix: unbind event handlers in `ScreenReader`

### DIFF
--- a/src/utils/ScreenReader.ts
+++ b/src/utils/ScreenReader.ts
@@ -75,14 +75,14 @@ export class AriaScreenReader implements ScreenReader {
   /**
    * Call this with an event target when a focus event occurs. Resolves when speaking is done.
    */
-  public onFocus = async (target?: EventTarget) => {
+  public async onFocus(target?: EventTarget) {
     await this.speakEventTarget(target)
   }
 
   /**
    * Call this with an event target when a click event occurs. Resolves when speaking is done.
    */
-  public onClick = async (target?: EventTarget) => {
+  public async onClick(target?: EventTarget) {
     await this.speakEventTarget(target)
   }
 


### PR DESCRIPTION
When I originally wrote theses they were being passed directly to `addEventListener` or e.g. a JSX `onFocus` attribute. Now there's more indirection and they're being called with the proper context.

Closes #988
