### PR TITLE
fix: only clean node descriptions at the top level

### DIFF
--- a/src/utils/ScreenReader.test.ts
+++ b/src/utils/ScreenReader.test.ts
@@ -108,6 +108,33 @@ describe('AriaScreenReader', () => {
     )
   })
 
+  it('describes text broken into multiple text nodes correctly', () => {
+    const tts = fakeTTS()
+    const asr = new AriaScreenReader(tts)
+
+    asr.speakNode(
+      h(
+        'span',
+        text('You may only select '),
+        text('1'),
+        text(' '),
+        text('candidate'),
+        text(' in this contest. To vote for'),
+        text(' '),
+        text('Adam Cramer and Greg Vuocolo'),
+        text(', you must first unselect the selected'),
+        text(' '),
+        text('candidate'),
+        text('.'),
+        h('span', text('Use the select button to continue.'))
+      )
+    )
+    expect(tts.speak).toHaveBeenCalledWith(
+      'You may only select 1 candidate in this contest. To vote for Adam Cramer and Greg Vuocolo, you must first unselect the selected candidate. Use the select button to continue.',
+      expect.anything()
+    )
+  })
+
   it('terminates block elements with a period', () => {
     const tts = fakeTTS()
     const asr = new AriaScreenReader(tts)

--- a/src/utils/ScreenReader.ts
+++ b/src/utils/ScreenReader.ts
@@ -142,18 +142,23 @@ export class AriaScreenReader implements ScreenReader {
   }
 
   /**
-   * Generates a text string to be spoken for an element.
+   * Generates a clean text string to be spoken for an element.
    */
   public describe(node: Node): string | undefined {
+    return this.cleanDescription(this.describeNode(node))
+  }
+
+  /**
+   * Assembles all text to be spoken for a node but does not clean it up yet.
+   */
+  private describeNode(node: Node): string | undefined {
     if (!(node instanceof Text) && !(node instanceof Element)) {
       return
     }
 
-    return this.cleanDescription(
-      node instanceof Text
-        ? this.describeText(node)
-        : this.describeElement(node)
-    )
+    return node instanceof Text
+      ? this.describeText(node)
+      : this.describeElement(node)
   }
 
   private cleanDescription(
@@ -163,7 +168,7 @@ export class AriaScreenReader implements ScreenReader {
       return
     }
     return description
-      .replace(/ {2}/g, ' ')
+      .replace(/ +/g, ' ')
       .replace(/^[. ]+/g, '')
       .replace(/\. +\./g, '.')
       .replace(/,\./g, '.')
@@ -196,7 +201,7 @@ export class AriaScreenReader implements ScreenReader {
       const element = document.getElementById(ariaLabeledBy)
 
       if (element) {
-        const description = this.describe(element)
+        const description = this.describeNode(element)
 
         if (description) {
           return description + terminator
@@ -206,7 +211,7 @@ export class AriaScreenReader implements ScreenReader {
 
     return (
       Array.from(node.childNodes)
-        .map(child => this.describe(child))
+        .map(child => this.describeNode(child))
         .filter(Boolean)
         .join(' ') + terminator
     )


### PR DESCRIPTION
There are often text nodes that contain only punctuation due to the way that the DOM is constructed. These should not be stripped out, so text cleaning should happen only at the level of a whole DOM tree rather than on each leaf in the tree.