### PR TITLE
fix: do not announce event targets that disappear

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,8 +72,11 @@ const App = ({
 
         setImmediate(() => {
           // Only send `onClick` to the screen reader if the click didn't
-          // trigger navigation.
-          if (window.location.pathname === currentPath) {
+          // trigger navigation and the clicked element is still here.
+          if (
+            window.location.pathname === currentPath &&
+            document.body.contains(target as Node)
+          ) {
             screenReader.onClick(target)
           }
         })
@@ -90,8 +93,11 @@ const App = ({
 
         setImmediate(() => {
           // Only send `onFocus` to the screen reader if the focus didn't
-          // trigger navigation.
-          if (window.location.pathname === currentPath) {
+          // trigger navigation and the focused element is still here.
+          if (
+            window.location.pathname === currentPath &&
+            document.body.contains(target as Node)
+          ) {
             screenReader.onFocus(target)
           }
         })

--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -275,25 +275,16 @@ class CandidateContest extends React.Component<Props, State> {
   }
 
   public closeAttemptedVoteAlert = () => {
-    // Delay to avoid passing tap to next screen
-    window.setTimeout(() => {
-      this.setState({ attemptedOvervoteCandidate: undefined })
-    }, 200)
+    this.setState({ attemptedOvervoteCandidate: undefined })
   }
 
   public confirmRemovePendingWriteInCandidate = () => {
-    // Delay to avoid passing tap to next screen
-    window.setTimeout(() => {
-      this.removeCandidateFromVote(this.state.candidatePendingRemoval!.id)
-    }, 200)
+    this.removeCandidateFromVote(this.state.candidatePendingRemoval!.id)
     this.clearCandidateIdPendingRemoval()
   }
 
   public clearCandidateIdPendingRemoval = () => {
-    // Delay to avoid passing tap to next screen
-    window.setTimeout(() => {
-      this.setState({ candidatePendingRemoval: undefined })
-    }, 200)
+    this.setState({ candidatePendingRemoval: undefined })
   }
 
   public initWriteInCandidate = () => {


### PR DESCRIPTION
When an event target, such as a modal dialog close button, is removed as a result of the event, we should not pass the event on to the screen reader.

Fixes #985 