### PR TITLE
refactor: inject card and storage APIs into app

### DIFF
--- a/cypress/tests/scroll-buttons.ts
+++ b/cypress/tests/scroll-buttons.ts
@@ -4,6 +4,7 @@ describe('Scroll Buttons', () => {
 
   it('Scroll buttons appear and function correctly', () => {
     cy.visit('/#sample')
+    cy.wait(waitTime)
     cy.get('nav')
       .contains('Start Voting')
       .click()

--- a/cypress/tests/scroll-to-contest.ts
+++ b/cypress/tests/scroll-to-contest.ts
@@ -5,6 +5,7 @@ describe('Review Page', () => {
   const clickThoughPages = new Array(20) // number of contests for activation code 'VX.23.12'
   it('When navigating from contest, scroll to contest and place focus on contest.', () => {
     cy.visit('/#sample')
+    cy.wait(waitTime)
     cy.get('nav')
       .contains('Start Voting')
       .click()

--- a/src/APICardCatch.test.tsx
+++ b/src/APICardCatch.test.tsx
@@ -19,7 +19,9 @@ beforeEach(() => {
 })
 
 it('Cause "/card/read" API to catch', async () => {
-  const failureResponse = jest.fn(() => undefined)
+  const failureResponse = jest.fn(() => {
+    throw new Error('NOPE')
+  })
   // Configure Machine
   setElectionInLocalStorage()
   setStateInLocalStorage()

--- a/src/APICardCatch.test.tsx
+++ b/src/APICardCatch.test.tsx
@@ -1,34 +1,38 @@
 import React from 'react'
 import { fireEvent, render, wait } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 
 import App from './App'
 
 import { advanceTimers } from '../test/helpers/smartcards'
 
 import {
-  setElectionInLocalStorage,
-  setStateInLocalStorage,
+  setElectionInStorage,
+  setStateInStorage,
 } from '../test/helpers/election'
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
+import { MemoryCard } from './utils/Card'
 
 jest.useFakeTimers()
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
 it('Cause "/card/read" API to catch', async () => {
-  const failureResponse = jest.fn(() => {
-    throw new Error('NOPE')
-  })
   // Configure Machine
-  setElectionInLocalStorage()
-  setStateInLocalStorage()
+  const storage = new MemoryStorage<AppStorage>()
+  const card = new MemoryCard()
+  setElectionInStorage(storage)
+  setStateInStorage(storage)
 
   // Mock Failed response
-  fetchMock.get('/card/read', failureResponse, { overwriteRoutes: true })
-  const { getByText } = render(<App />)
+  const readStatusMock = jest
+    .spyOn(card, 'readStatus')
+    .mockImplementation(() => {
+      throw new Error('NOPE')
+    })
+  const { getByText } = render(<App storage={storage} card={card} />)
 
   // Ensure card polling interval time is passed
   advanceTimers()
@@ -37,11 +41,11 @@ it('Cause "/card/read" API to catch', async () => {
   await wait(() => fireEvent.click(getByText('Insert Card')))
 
   // Expect that card API was called once
-  expect(failureResponse).toHaveBeenCalledTimes(1)
+  expect(readStatusMock).toHaveBeenCalledTimes(1)
 
   // Ensure card polling interval time is passed again
   advanceTimers()
 
   // Expect that card API has not been called again
-  expect(failureResponse).toHaveBeenCalledTimes(1)
+  expect(readStatusMock).toHaveBeenCalledTimes(1)
 })

--- a/src/APIMachineIdCatch.test.tsx
+++ b/src/APIMachineIdCatch.test.tsx
@@ -3,9 +3,10 @@ import { render } from '@testing-library/react'
 import fetchMock from 'fetch-mock'
 
 import App from './App'
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
@@ -18,7 +19,7 @@ it('Cause "/machine-id" API to catch', async () => {
   )
 
   // Render app which calls machineId api in componentDidMount
-  render(<App />)
+  render(<App storage={new MemoryStorage<AppStorage>()} />)
 
   // No expect?
   // Unfortunately, the only thing this test does is provide code-coverage
@@ -32,7 +33,7 @@ it('/machine-id fails with bad gateway response', async () => {
   })
 
   // Render app which calls machineId api in componentDidMount
-  render(<App />)
+  render(<App storage={new MemoryStorage<AppStorage>()} />)
 
   // No expect?
   // Unfortunately, the only thing this test does is provide code-coverage

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import './App.css'
 
 import FocusManager from './components/FocusManager'
 
-import AppRoot from './AppRoot'
+import AppRoot, { Props as AppRootProps, AppStorage } from './AppRoot'
 import {
   ScreenReader,
   AriaScreenReader,
@@ -14,6 +14,8 @@ import {
   NullTextToSpeech,
   TextToSpeech,
 } from './utils/ScreenReader'
+import { WebServiceCard } from './utils/Card'
+import { LocalStorage } from './utils/Storage'
 
 window.oncontextmenu = (e: MouseEvent): void => {
   e.preventDefault()
@@ -24,6 +26,8 @@ export interface Props {
     enabled: TextToSpeech
     disabled: TextToSpeech
   }
+  card?: AppRootProps['card']
+  storage?: AppRootProps['storage']
 }
 
 const App = ({
@@ -31,6 +35,8 @@ const App = ({
     enabled: new SpeechSynthesisTextToSpeech(),
     disabled: new NullTextToSpeech(),
   },
+  card = new WebServiceCard(),
+  storage = new LocalStorage<AppStorage>(),
 }: Props) => {
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false)
   const [screenReader, setScreenReader] = useState<ScreenReader>(
@@ -113,7 +119,10 @@ const App = ({
         onClickCapture={onClick}
         onFocusCapture={onFocus}
       >
-        <Route path="/" component={AppRoot} />
+        <Route
+          path="/"
+          render={props => <AppRoot card={card} storage={storage} {...props} />}
+        />
       </FocusManager>
     </BrowserRouter>
   )

--- a/src/AppContestMultiSeat.test.tsx
+++ b/src/AppContestMultiSeat.test.tsx
@@ -1,50 +1,40 @@
 import React from 'react'
 import { fireEvent, render, wait } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 
 import App from './App'
 
-import {
-  advanceTimers,
-  getNewVoterCard,
-  noCard,
-} from '../test/helpers/smartcards'
+import { advanceTimers, getNewVoterCard } from '../test/helpers/smartcards'
 
 import {
   countyCommissionersContest,
-  setElectionInLocalStorage,
-  setStateInLocalStorage,
+  setElectionInStorage,
+  setStateInStorage,
 } from '../test/helpers/election'
-
-let currentCard = noCard
-fetchMock.get('/card/read', () => JSON.stringify(currentCard))
-fetchMock.post('/card/write', (url, options) => {
-  currentCard = {
-    present: true,
-    shortValue: options.body as string,
-  }
-  return ''
-})
-
-fetchMock.post('/card/write_long_b64', () => JSON.stringify({ status: 'ok' }))
+import { MemoryCard } from './utils/Card'
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
 
 jest.useFakeTimers()
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  setElectionInLocalStorage()
-  setStateInLocalStorage()
+  const storage = new MemoryStorage<AppStorage>()
+  const card = new MemoryCard()
 
-  const { container, getByText, queryByText } = render(<App />)
+  setElectionInStorage(storage)
+  setStateInStorage(storage)
+
+  const { container, getByText, queryByText } = render(
+    <App storage={storage} card={card} />
+  )
 
   // Insert Voter Card
-  currentCard = getNewVoterCard()
+  card.insertCard(getNewVoterCard())
   advanceTimers()
 
   // Go to First Contest

--- a/src/AppContestSingleSeat.test.tsx
+++ b/src/AppContestSingleSeat.test.tsx
@@ -1,48 +1,38 @@
 import React from 'react'
 import { fireEvent, render, wait } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 
 import App from './App'
 
-import {
-  advanceTimers,
-  getNewVoterCard,
-  noCard,
-} from '../test/helpers/smartcards'
+import { advanceTimers, getNewVoterCard } from '../test/helpers/smartcards'
 
 import {
   presidentContest,
-  setElectionInLocalStorage,
-  setStateInLocalStorage,
+  setElectionInStorage,
+  setStateInStorage,
 } from '../test/helpers/election'
-
-let currentCard = noCard
-fetchMock.get('/card/read', () => JSON.stringify(currentCard))
-fetchMock.post('/card/write', (url, options) => {
-  currentCard = {
-    present: true,
-    shortValue: options.body as string,
-  }
-  return ''
-})
+import { MemoryCard } from './utils/Card'
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
 
 jest.useFakeTimers()
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  setElectionInLocalStorage()
-  setStateInLocalStorage()
+  const storage = new MemoryStorage<AppStorage>()
+  const card = new MemoryCard()
 
-  const { container, getByText } = render(<App />)
+  setElectionInStorage(storage)
+  setStateInStorage(storage)
+
+  const { container, getByText } = render(<App storage={storage} card={card} />)
 
   // Insert Voter Card
-  currentCard = getNewVoterCard()
+  card.insertCard(getNewVoterCard())
   advanceTimers()
 
   // Go to First Contest

--- a/src/AppContestYesNo.test.tsx
+++ b/src/AppContestYesNo.test.tsx
@@ -1,50 +1,42 @@
 import React from 'react'
 import { fireEvent, render, wait, within } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 
 import App from './App'
 
 import withMarkup from '../test/helpers/withMarkup'
 
-import {
-  advanceTimers,
-  getNewVoterCard,
-  noCard,
-} from '../test/helpers/smartcards'
+import { advanceTimers, getNewVoterCard } from '../test/helpers/smartcards'
 
 import {
   measure102Contest,
-  setElectionInLocalStorage,
-  setStateInLocalStorage,
+  setElectionInStorage,
+  setStateInStorage,
 } from '../test/helpers/election'
-
-let currentCard = noCard
-fetchMock.get('/card/read', () => JSON.stringify(currentCard))
-fetchMock.post('/card/write', (url, options) => {
-  currentCard = {
-    present: true,
-    shortValue: options.body as string,
-  }
-  return ''
-})
+import { MemoryCard } from './utils/Card'
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
 
 jest.useFakeTimers()
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  setElectionInLocalStorage()
-  setStateInLocalStorage()
+  const storage = new MemoryStorage<AppStorage>()
+  const card = new MemoryCard()
 
-  const { getByText, queryByText, getByTestId } = render(<App />)
+  setElectionInStorage(storage)
+  setStateInStorage(storage)
+
+  const { getByText, queryByText, getByTestId } = render(
+    <App storage={storage} card={card} />
+  )
 
   // Insert Voter Card
-  currentCard = getNewVoterCard()
+  card.insertCard(getNewVoterCard())
   advanceTimers()
 
   // Go to First Contest

--- a/src/AppData.test.tsx
+++ b/src/AppData.test.tsx
@@ -3,19 +3,19 @@ import { render, wait } from '@testing-library/react'
 
 import App from './App'
 import SampleApp, { getSampleStorage } from './SampleApp'
-import { activationStorageKey, electionStorageKey } from './AppRoot'
+import { activationStorageKey, electionStorageKey, AppStorage } from './AppRoot'
 
 import {
   election,
-  setElectionInLocalStorage,
-  setStateInLocalStorage,
+  setElectionInStorage,
+  setStateInStorage,
 } from '../test/helpers/election'
 import { advanceTimers } from '../test/helpers/smartcards'
+import { MemoryStorage } from './utils/Storage'
 
 jest.useFakeTimers()
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
@@ -38,11 +38,12 @@ describe('loads election', () => {
     expect(storage.get(activationStorageKey)).toBeTruthy()
   })
 
-  it('from localStorage', () => {
-    setElectionInLocalStorage()
-    setStateInLocalStorage()
-    const { getByText } = render(<App />)
+  it('from storage', () => {
+    const storage = new MemoryStorage<AppStorage>()
+    setElectionInStorage(storage)
+    setStateInStorage(storage)
+    const { getByText } = render(<App storage={storage} />)
     getByText(election.title)
-    expect(window.localStorage.getItem(electionStorageKey)).toBeTruthy()
+    expect(storage.get(electionStorageKey)).toBeTruthy()
   })
 })

--- a/src/AppData.test.tsx
+++ b/src/AppData.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, wait } from '@testing-library/react'
 
 import App from './App'
+import SampleApp, { getSampleStorage } from './SampleApp'
 import { activationStorageKey, electionStorageKey } from './AppRoot'
 
 import {
@@ -9,6 +10,7 @@ import {
   setElectionInLocalStorage,
   setStateInLocalStorage,
 } from '../test/helpers/election'
+import { advanceTimers } from '../test/helpers/smartcards'
 
 jest.useFakeTimers()
 
@@ -23,14 +25,17 @@ describe('loads election', () => {
     getByText('Device Not Configured')
   })
 
-  it('#sample url hash loads elecation and activates ballot', () => {
-    window.location.href = '/#sample'
-    const { getAllByText, getByText } = render(<App />)
-    expect(getAllByText(election.title).length).toBeGreaterThan(1)
-    getByText(/Center Springfield/)
-    getByText(/ballot style 12/)
-    expect(window.localStorage.getItem(electionStorageKey)).toBeTruthy()
-    expect(window.localStorage.getItem(activationStorageKey)).toBeTruthy()
+  it('sample app loads election and activates ballot', async () => {
+    const storage = getSampleStorage()
+    const { getAllByText, getByText } = render(<SampleApp storage={storage} />)
+    advanceTimers()
+    await wait(() => {
+      expect(getAllByText(election.title).length).toBeGreaterThan(1)
+      getByText(/Center Springfield/)
+      getByText(/ballot style 12/)
+    })
+    expect(storage.get(electionStorageKey)).toBeTruthy()
+    expect(storage.get(activationStorageKey)).toBeTruthy()
   })
 
   it('from localStorage', () => {

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -12,7 +12,6 @@ import {
   Election,
   OptionalElection,
 } from '@votingworks/ballot-encoder'
-import { fromByteArray, toByteArray } from 'base64-js'
 import 'normalize.css'
 import React from 'react'
 import Gamepad from 'react-gamepad'
@@ -39,9 +38,9 @@ import {
   CandidateVoteTally,
   getAppMode,
   YesNoVoteTally,
+  SerializableActivationData,
 } from './config/types'
 import BallotContext from './contexts/ballotContext'
-import electionSample from './data/electionSample.json'
 import {
   handleGamepadButtonDown,
   handleGamepadKeyboardEvent,
@@ -59,6 +58,9 @@ import { getBallotStyle, getContests, getZeroTally } from './utils/election'
 import fetchJSON from './utils/fetchJSON'
 import makePrinter, { PrintMethod } from './utils/printer'
 import utcTimestamp from './utils/utcTimestamp'
+import { Card } from './utils/Card'
+import { Poller, IntervalPoller } from './utils/polling'
+import { Storage } from './utils/Storage'
 
 interface CardState {
   isClerkCardPresent: boolean
@@ -90,23 +92,35 @@ interface SharedState {
   isLiveMode: boolean
   isPollsOpen: boolean
   machineId: string
-  shortValue: string
+  shortValue?: string
   tally: Tally
 }
 
 interface State extends CardState, UserState, SharedState {}
 
+export interface AppStorage {
+  election?: Election
+  state?: Partial<State>
+  activation?: SerializableActivationData
+  votes?: VotesDict
+}
+
+export interface Props extends RouteComponentProps {
+  card: Card
+  storage: Storage<AppStorage>
+}
+
 export const electionStorageKey = 'election'
 export const stateStorageKey = 'state'
 export const activationStorageKey = 'activation'
-const votesStorageKey = 'votes'
+export const votesStorageKey = 'votes'
 
 const printer = makePrinter(PrintMethod.RemoteWithLocalFallback)
 
-class AppRoot extends React.Component<RouteComponentProps, State> {
+class AppRoot extends React.Component<Props, State> {
   private machineIdAbortController = new AbortController()
 
-  private checkCardInterval = 0
+  private cardPoller?: Poller
   private lastVoteUpdateAt = 0
   private lastVoteSaveToCardAt = 0
   private cardWriteInterval = 0
@@ -171,21 +185,18 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
   public fetchElection = async () => {
     this.setState({ isFetchingElection: true })
     try {
-      const response = await fetch('/card/read_long')
-      const election = await response.json()
-      this.setElection(JSON.parse(election.longValue))
+      this.setElection((await this.props.card.readLongObject<Election>())!)
     } finally {
       this.setState({ isFetchingElection: false })
     }
   }
 
   public fetchBallotData = async () => {
-    const response = await fetch('/card/read_long_b64')
-    const { longValue } = await response.json()
+    const longValue = (await this.props.card.readLongUint8Array())!
     /* istanbul ignore else */
     if (longValue) {
       const election = this.state.election!
-      const { ballot } = decodeBallot(election, toByteArray(longValue))
+      const { ballot } = decodeBallot(election, longValue)
       return ballot
     } else {
       return undefined
@@ -213,7 +224,7 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
     longValueExists,
     shortValue,
   }: CardPresentAPI) => {
-    const cardData: CardData = JSON.parse(shortValue)
+    const cardData: CardData = JSON.parse(shortValue!)
     switch (cardData.t) {
       case 'voter': {
         const voterCardData = cardData as VoterCardData
@@ -292,57 +303,51 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
   }
 
   public startShortValueReadPolling = () => {
-    if (this.checkCardInterval === 0) {
+    /* istanbul ignore else */
+    if (!this.cardPoller) {
       let lastCardDataString = ''
 
-      this.checkCardInterval = window.setInterval(async () => {
-        try {
-          const card = await this.readCard()
-          if (this.state.pauseProcessingUntilNoCardPresent) {
-            if (card.present) {
+      this.cardPoller = IntervalPoller.start(
+        GLOBALS.CARD_POLLING_INTERVAL,
+        async () => {
+          try {
+            const card = await this.props.card.readStatus()
+            if (this.state.pauseProcessingUntilNoCardPresent) {
+              if (card.present) {
+                return
+              }
+              this.setPauseProcessingUntilNoCardPresent(false)
+            }
+            const currentCardDataString = JSON.stringify(card)
+            if (currentCardDataString === lastCardDataString) {
               return
             }
-            this.setPauseProcessingUntilNoCardPresent(false)
-          }
-          const currentCardDataString = JSON.stringify(card)
-          if (currentCardDataString === lastCardDataString) {
-            return
-          }
-          lastCardDataString = currentCardDataString
+            lastCardDataString = currentCardDataString
 
-          if (!card.present || !card.shortValue) {
+            if (!card.present || !card.shortValue) {
+              this.resetBallot()
+              return
+            }
+
+            this.processCard(card)
+          } catch (error) {
             this.resetBallot()
-            return
+            lastCardDataString = ''
+            this.stopShortValueReadPolling() // Assume backend is unavailable.
           }
-
-          this.processCard(card)
-        } catch (error) {
-          this.resetBallot()
-          lastCardDataString = ''
-          this.stopShortValueReadPolling() // Assume backend is unavailable.
         }
-      }, GLOBALS.CARD_POLLING_INTERVAL)
+      )
     }
   }
 
   public stopShortValueReadPolling = () => {
-    window.clearInterval(this.checkCardInterval)
-    this.checkCardInterval = 0 // To indicate setInterval is not running.
-  }
-
-  public saveLongValue = async (longValueBase64: string) => {
-    const formData = new FormData()
-    formData.append('long_value', longValueBase64)
-
-    await fetch('/card/write_long_b64', {
-      method: 'post',
-      body: formData,
-    })
+    this.cardPoller && this.cardPoller.stop()
+    this.cardPoller = undefined
   }
 
   public clearLongValue = async () => {
     this.writingVoteToCard = true
-    await this.saveLongValue('')
+    await this.props.card.writeLongUint8Array(Uint8Array.of())
     this.writingVoteToCard = false
   }
 
@@ -375,11 +380,11 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
             isTestBallot: !this.state.isLiveMode,
             ballotType: BallotType.Standard,
           }
-          const longValue = fromByteArray(encodeBallot(ballot))
+          const longValue = encodeBallot(ballot)
 
           this.writingVoteToCard = true
           try {
-            await this.saveLongValue(longValue)
+            await this.props.card.writeLongUint8Array(longValue)
           } catch (error) {
             // eslint-disable-next-line no-empty
           }
@@ -399,7 +404,7 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
     await this.clearLongValue()
 
     const currentVoterCardData: VoterCardData = JSON.parse(
-      this.state.shortValue
+      this.state.shortValue!
     )
     const voidedVoterCardData: VoterCardData = {
       ...currentVoterCardData,
@@ -409,7 +414,7 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
 
     const updatedCard = await this.readCard()
     const updatedShortValue: VoterCardData =
-      updatedCard.present && JSON.parse(updatedCard.shortValue)
+      updatedCard.present && JSON.parse(updatedCard.shortValue!)
 
     this.startShortValueReadPolling()
 
@@ -427,7 +432,7 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
     await this.clearLongValue()
 
     const currentVoterCardData: VoterCardData = JSON.parse(
-      this.state.shortValue
+      this.state.shortValue!
     )
 
     const usedVoterCardData: VoterCardData = {
@@ -438,7 +443,7 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
 
     const updatedCard = await this.readCard()
     const updatedShortValue: VoterCardData =
-      updatedCard.present && JSON.parse(updatedCard.shortValue)
+      updatedCard.present && JSON.parse(updatedCard.shortValue!)
 
     this.startShortValueReadPolling()
 
@@ -451,81 +456,40 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
   }
 
   public componentDidMount = () => {
-    if (window.location.hash === '#sample') {
-      this.checkCardInterval = 1 // don't poll for card data.
-      this.setState(
-        {
-          election: electionSample as Election,
-          appPrecinctId: '23',
-          ballotsPrintedCount: 0,
-          isLiveMode: true,
-          isPollsOpen: true,
-          ballotCreatedAt: utcTimestamp(),
-          ballotStyleId: '12',
-          precinctId: '23',
-        },
-        () => {
-          const {
-            ballotCreatedAt,
-            ballotStyleId,
-            precinctId,
-            election,
-          } = this.state
-          this.setBallotActivation({
-            ballotCreatedAt,
-            ballotStyleId,
-            precinctId,
-          })
-          this.setElection(election as Election)
-          const voterCardData: VoterCardData = {
-            c: utcTimestamp(),
-            t: 'voter',
-            bs: ballotStyleId,
-            pr: precinctId,
-          }
-          this.processCard({
-            present: true,
-            shortValue: JSON.stringify(voterCardData),
-            longValueExists: false,
-          })
-        }
-      )
-    } else {
-      const election = this.getElection()
-      const { ballotStyleId, precinctId } = this.getBallotActivation()
-      const {
-        appMode = this.initialState.appMode,
-        appPrecinctId = this.initialState.appPrecinctId,
-        ballotsPrintedCount = this.initialState.ballotsPrintedCount,
-        isLiveMode = this.initialState.isLiveMode,
-        isPollsOpen = this.initialState.isPollsOpen,
-        tally = this.initialState.tally,
-      } = this.getStoredState()
-      const ballotStyle =
-        ballotStyleId &&
-        election &&
-        getBallotStyle({
-          ballotStyleId,
-          election,
-        })
-      const contests =
-        ballotStyle && election
-          ? getContests({ ballotStyle, election })
-          : this.initialState.contests
-      this.setState({
-        appMode,
-        appPrecinctId,
-        ballotsPrintedCount,
+    const election = this.getElection()
+    const { ballotStyleId, precinctId } = this.getBallotActivation()
+    const {
+      appMode = this.initialState.appMode,
+      appPrecinctId = this.initialState.appPrecinctId,
+      ballotsPrintedCount = this.initialState.ballotsPrintedCount,
+      isLiveMode = this.initialState.isLiveMode,
+      isPollsOpen = this.initialState.isPollsOpen,
+      tally = this.initialState.tally,
+    } = this.getStoredState()
+    const ballotStyle =
+      ballotStyleId &&
+      election &&
+      getBallotStyle({
         ballotStyleId,
-        contests,
         election,
-        isLiveMode,
-        isPollsOpen,
-        precinctId,
-        tally,
-        votes: this.getVotes(),
       })
-    }
+    const contests =
+      ballotStyle && election
+        ? getContests({ ballotStyle, election })
+        : this.initialState.contests
+    this.setState({
+      appMode,
+      appPrecinctId,
+      ballotsPrintedCount,
+      ballotStyleId,
+      contests,
+      election,
+      isLiveMode,
+      isPollsOpen,
+      precinctId,
+      tally,
+      votes: this.getVotes(),
+    })
     document.addEventListener('keydown', handleGamepadKeyboardEvent)
     document.documentElement.setAttribute('data-useragent', navigator.userAgent)
     this.setDocumentFontSize()
@@ -553,66 +517,58 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
   }
 
   public readCard = async (): Promise<CardAPI> => {
-    return await fetchJSON<CardAPI>('/card/read')
+    return await this.props.card.readStatus()
   }
 
   public writeCard = async (cardData: VoterCardData) => {
-    await fetch('/card/write', {
-      method: 'post',
-      body: JSON.stringify(cardData),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    await this.props.card.writeShortValue(JSON.stringify(cardData))
   }
 
   public getElection = (): OptionalElection => {
-    const election = window.localStorage.getItem(electionStorageKey)
-    return election ? JSON.parse(election) : undefined
+    return this.props.storage.get(electionStorageKey)
   }
 
   public setElection = (electionConfigFile: Election) => {
     const election = electionConfigFile
     this.setState({ election }, this.resetTally)
-    window.localStorage.setItem(electionStorageKey, JSON.stringify(election))
+    this.props.storage.set(electionStorageKey, election)
   }
 
-  public getBallotActivation = () => {
-    const activationData = window.localStorage.getItem(activationStorageKey)
-    return activationData ? JSON.parse(activationData) : {}
+  public getBallotActivation = (): SerializableActivationData => {
+    return (
+      this.props.storage.get(activationStorageKey) ||
+      (({} as unknown) as SerializableActivationData)
+    )
   }
 
-  public setBallotActivation = (data: {
-    ballotCreatedAt: number
-    ballotStyleId: string
-    precinctId: string
-  }) => {
+  public setBallotActivation = (data: SerializableActivationData) => {
     /* istanbul ignore else */
     if (process.env.NODE_ENV !== 'production') {
-      window.localStorage.setItem(activationStorageKey, JSON.stringify(data))
+      this.props.storage.set(activationStorageKey, data)
     }
   }
 
   public getVotes = () => {
-    const votesData = window.localStorage.getItem(votesStorageKey)
-    return votesData ? JSON.parse(votesData) : {}
+    return this.props.storage.get(votesStorageKey) || {}
   }
 
   public setVotes = async (votes: VotesDict) => {
     /* istanbul ignore else */
     if (process.env.NODE_ENV !== 'production') {
-      window.localStorage.setItem(votesStorageKey, JSON.stringify(votes))
+      this.props.storage.set(votesStorageKey, votes)
     }
 
     this.lastVoteUpdateAt = Date.now()
   }
 
   public resetVoterData = () => {
-    window.localStorage.removeItem(activationStorageKey)
-    window.localStorage.removeItem(votesStorageKey)
+    this.props.storage.remove(activationStorageKey)
+    this.props.storage.remove(votesStorageKey)
   }
 
   public unconfigure = () => {
     this.setState(this.initialState)
-    window.localStorage.clear()
+    this.props.storage.clear()
     this.props.history.push('/')
   }
 
@@ -625,24 +581,18 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
       isPollsOpen,
       tally,
     } = this.state
-    window.localStorage.setItem(
-      stateStorageKey,
-      JSON.stringify({
-        appMode,
-        appPrecinctId,
-        ballotsPrintedCount,
-        isLiveMode,
-        isPollsOpen,
-        tally,
-      })
-    )
+    this.props.storage.set(stateStorageKey, {
+      appMode,
+      appPrecinctId,
+      ballotsPrintedCount,
+      isLiveMode,
+      isPollsOpen,
+      tally,
+    })
   }
 
   public getStoredState = (): Partial<State> => {
-    const storedStateJSON = window.localStorage.getItem(stateStorageKey)
-    const storedState: Partial<State> = storedStateJSON
-      ? JSON.parse(storedStateJSON)
-      : {}
+    const storedState = this.props.storage.get(stateStorageKey) || {}
 
     if (storedState.appMode) {
       try {
@@ -693,7 +643,6 @@ class AppRoot extends React.Component<RouteComponentProps, State> {
       precinctId: precinct.id,
     })
     this.setState(prevState => ({
-      ballotCreatedAt,
       ballotStyleId: ballotStyle.id,
       contests: getContests({ ballotStyle, election: prevState.election! }),
       precinctId: precinct.id,

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -418,6 +418,7 @@ class AppRoot extends React.Component<Props, State> {
 
     this.startShortValueReadPolling()
 
+    /* istanbul ignore next - this should never happen */
     if (voidedVoterCardData.uz !== updatedShortValue.uz) {
       this.resetBallot()
       return false

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -96,7 +96,7 @@ interface SharedState {
   tally: Tally
 }
 
-interface State extends CardState, UserState, SharedState {}
+export interface State extends CardState, UserState, SharedState {}
 
 export interface AppStorage {
   election?: Election

--- a/src/AppTestMode.test.tsx
+++ b/src/AppTestMode.test.tsx
@@ -4,22 +4,24 @@ import { render } from '@testing-library/react'
 import App from './App'
 
 import {
-  setElectionInLocalStorage,
-  setStateInLocalStorage,
+  setElectionInStorage,
+  setStateInStorage,
 } from '../test/helpers/election'
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
 
 jest.useFakeTimers()
 
 beforeEach(() => {
-  window.localStorage.clear()
   window.location.href = '/'
 })
 
 it('Displays testing message if not live mode', () => {
-  setElectionInLocalStorage()
-  setStateInLocalStorage({
+  const storage = new MemoryStorage<AppStorage>()
+  setElectionInStorage(storage)
+  setStateInStorage(storage, {
     isLiveMode: false,
   })
-  const { getByText } = render(<App />)
+  const { getByText } = render(<App storage={storage} />)
   getByText('Testing Mode')
 })

--- a/src/SampleApp.tsx
+++ b/src/SampleApp.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { VoterCardData, electionSample } from '@votingworks/ballot-encoder'
+import App, { Props } from './App'
+import { Card, MemoryCard } from './utils/Card'
+import utcTimestamp from './utils/utcTimestamp'
+import { Storage, MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
+
+const ballotStyleId = '12'
+const precinctId = '23'
+
+export function getSampleCard(): Card {
+  const voterCardData: VoterCardData = {
+    c: utcTimestamp(),
+    t: 'voter',
+    bs: ballotStyleId,
+    pr: precinctId,
+  }
+
+  return new MemoryCard().insertCard(JSON.stringify(voterCardData))
+}
+
+export function getSampleStorage(): Storage<AppStorage> {
+  const election = electionSample
+  const ballotCreatedAt = utcTimestamp()
+  const ballotStyleId = '12'
+  const precinctId = '23'
+  const appPrecinctId = '23'
+
+  return new MemoryStorage<AppStorage>({
+    state: {
+      election,
+      appPrecinctId,
+      ballotsPrintedCount: 0,
+      isLiveMode: true,
+      isPollsOpen: true,
+      ballotCreatedAt,
+      ballotStyleId,
+      precinctId,
+    },
+
+    election,
+    activation: {
+      ballotCreatedAt,
+      ballotStyleId,
+      precinctId,
+    },
+  })
+}
+
+/* istanbul ignore next */
+const SampleApp = ({
+  card = getSampleCard(),
+  storage = getSampleStorage(),
+  ...rest
+}: Props) => <App card={card} storage={storage} {...rest} />
+
+export default SampleApp

--- a/src/SampleApp.tsx
+++ b/src/SampleApp.tsx
@@ -8,6 +8,7 @@ import { AppStorage } from './AppRoot'
 
 const ballotStyleId = '12'
 const precinctId = '23'
+const appPrecinctId = '23'
 
 export function getSampleCard(): Card {
   const voterCardData: VoterCardData = {
@@ -23,9 +24,6 @@ export function getSampleCard(): Card {
 export function getSampleStorage(): Storage<AppStorage> {
   const election = electionSample
   const ballotCreatedAt = utcTimestamp()
-  const ballotStyleId = '12'
-  const precinctId = '23'
-  const appPrecinctId = '23'
 
   return new MemoryStorage<AppStorage>({
     state: {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,12 @@ export interface ActivationData {
   precinct: Precinct
 }
 
+export interface SerializableActivationData {
+  ballotCreatedAt: number
+  ballotStyleId: string
+  precinctId: string
+}
+
 // Votes
 export interface WriteInCandidateTally {
   name: string
@@ -116,7 +122,7 @@ export interface CardAbsentAPI {
 }
 export interface CardPresentAPI {
   present: true
-  shortValue: string
+  shortValue?: string
   longValueExists?: boolean
 }
 export type CardAPI = CardAbsentAPI | CardPresentAPI

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,14 @@ import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
+import SampleApp from './SampleApp'
 
 import * as serviceWorker from './serviceWorker'
 
-ReactDOM.render(<App />, document.getElementById('root')!)
+ReactDOM.render(
+  window.location.hash === '#sample' ? <SampleApp /> : <App />,
+  document.getElementById('root')!
+)
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/pages/ClerkScreen.test.tsx
+++ b/src/pages/ClerkScreen.test.tsx
@@ -1,20 +1,16 @@
 import React from 'react'
 import { fireEvent, within } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 
 import { render } from '../../test/testUtils'
 
 import { election, defaultPrecinctId } from '../../test/helpers/election'
 
-import { adminCard, advanceTimers, noCard } from '../../test/helpers/smartcards'
+import { advanceTimers } from '../../test/helpers/smartcards'
 
 import ClerkScreen from './ClerkScreen'
 import { VxPrintOnly } from '../config/types'
 
 jest.useFakeTimers()
-
-let currentCard = noCard
-fetchMock.get('/card/read', () => JSON.stringify(currentCard))
 
 it('renders ClerkScreen', async () => {
   const { getByText, getByTestId } = render(
@@ -34,7 +30,6 @@ it('renders ClerkScreen', async () => {
   )
 
   // Configure with Admin Card
-  currentCard = adminCard
   advanceTimers()
 
   // View Test Ballot Decks

--- a/src/pages/PollWorkerScreen.test.tsx
+++ b/src/pages/PollWorkerScreen.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import fetchMock from 'fetch-mock'
 import { Election } from '@votingworks/ballot-encoder'
 
 import { VxMarkOnly } from '../config/types'
@@ -9,20 +8,13 @@ import { render } from '../../test/testUtils'
 import electionSampleWithSeal from '../data/electionSampleWithSeal.json'
 import { defaultPrecinctId } from '../../test/helpers/election'
 
-import {
-  advanceTimers,
-  noCard,
-  pollWorkerCard,
-} from '../../test/helpers/smartcards'
+import { advanceTimers } from '../../test/helpers/smartcards'
 
 import PollWorkerScreen from './PollWorkerScreen'
 import { NullPrinter } from '../utils/printer'
 import { getZeroTally } from '../utils/election'
 
 jest.useFakeTimers()
-
-let currentCard = noCard
-fetchMock.get('/card/read', () => JSON.stringify(currentCard))
 
 it('renders PollWorkerScreen', async () => {
   const election = electionSampleWithSeal as Election
@@ -41,8 +33,6 @@ it('renders PollWorkerScreen', async () => {
     />
   )
 
-  // Configure with Poll Worker  Card
-  currentCard = pollWorkerCard
   advanceTimers()
 
   getByText('Polls are currently open.')

--- a/src/utils/Card.test.ts
+++ b/src/utils/Card.test.ts
@@ -1,0 +1,178 @@
+import fetchMock, { MockRequest } from 'fetch-mock'
+import { fromByteArray, toByteArray } from 'base64-js'
+import { WebServiceCard, MemoryCard } from './Card'
+
+describe('WebServiceCard', () => {
+  it('fetches card status and short value from /card/read', async () => {
+    fetchMock.get('/card/read', {
+      present: true,
+      shortValue: 'abc',
+      longValueExists: true,
+    })
+
+    expect(await new WebServiceCard().readStatus()).toEqual({
+      present: true,
+      shortValue: 'abc',
+      longValueExists: true,
+    })
+  })
+
+  it('reads objects from /card/read_long', async () => {
+    fetchMock.get('/card/read_long', {
+      longValue: JSON.stringify({ a: 1, b: 2 }),
+    })
+
+    expect(await new WebServiceCard().readLongObject()).toEqual({
+      a: 1,
+      b: 2,
+    })
+  })
+
+  it('reads binary data from /card/read_long_b64', async () => {
+    fetchMock.get('/card/read_long_b64', {
+      longValue: fromByteArray(Uint8Array.of(1, 2, 3)),
+    })
+
+    expect(await new WebServiceCard().readLongUint8Array()).toEqual(
+      Uint8Array.of(1, 2, 3)
+    )
+  })
+
+  it('writes short value using /card/write', async () => {
+    fetchMock.post('/card/write', (url: string, mockRequest: MockRequest) => {
+      expect(mockRequest.body).toEqual('abc')
+      return { success: true }
+    })
+
+    await new WebServiceCard().writeShortValue('abc')
+  })
+
+  it('writes objects using /card/write_long_b64', async () => {
+    fetchMock.post(
+      '/card/write_long_b64',
+      (url: string, mockRequest: MockRequest) => {
+        const longValue = (mockRequest.body as FormData).get(
+          'long_value'
+        ) as string
+        const longObject = JSON.parse(
+          new TextDecoder().decode(toByteArray(longValue))
+        )
+
+        expect(longObject).toEqual({ a: 1 })
+        return { success: true }
+      }
+    )
+
+    await new WebServiceCard().writeLongObject({ a: 1 })
+  })
+
+  it('writes binary data using /card/write_long_b64', async () => {
+    fetchMock.post(
+      '/card/write_long_b64',
+      (url: string, mockRequest: MockRequest) => {
+        const longValue = (mockRequest.body as FormData).get(
+          'long_value'
+        ) as string
+        const longObject = toByteArray(longValue)
+
+        expect(longObject).toEqual(Uint8Array.of(1, 2, 3))
+        return { success: true }
+      }
+    )
+
+    await new WebServiceCard().writeLongUint8Array(Uint8Array.of(1, 2, 3))
+  })
+
+  it('gets undefined when reading object value if long value is not set', async () => {
+    fetchMock.get('/card/read_long', {})
+
+    expect(await new WebServiceCard().readLongObject()).toBeUndefined()
+  })
+
+  it('gets undefined when reading binary value if long value is not set', async () => {
+    fetchMock.get('/card/read_long_b64', {})
+
+    expect(await new WebServiceCard().readLongUint8Array()).toBeUndefined()
+  })
+})
+
+describe('MemoryCard', () => {
+  it('defaults to no card', async () => {
+    expect(await new MemoryCard().readStatus()).toEqual({
+      present: false,
+    })
+  })
+
+  it('can round-trip a short value', async () => {
+    const card = new MemoryCard().insertCard()
+
+    await card.writeShortValue('abc')
+    expect(await card.readStatus()).toEqual(
+      expect.objectContaining({
+        shortValue: 'abc',
+      })
+    )
+  })
+
+  it('can round-trip an object long value', async () => {
+    const card = new MemoryCard().insertCard()
+
+    await card.writeLongObject({ a: 1 })
+    expect(await card.readLongObject()).toEqual({ a: 1 })
+  })
+
+  it('can round-trip a binary long value', async () => {
+    const card = new MemoryCard().insertCard()
+
+    await card.writeLongUint8Array(Uint8Array.of(1, 2, 3))
+    expect(await card.readLongUint8Array()).toEqual(Uint8Array.of(1, 2, 3))
+  })
+
+  it('can set a short and long value using #insertCard', async () => {
+    const card = new MemoryCard().insertCard('abc', Uint8Array.of(1, 2, 3))
+
+    expect(await card.readStatus()).toEqual({
+      present: true,
+      shortValue: 'abc',
+      longValueExists: true,
+    })
+
+    expect(await card.readLongUint8Array()).toEqual(Uint8Array.of(1, 2, 3))
+
+    card.insertCard(undefined, { a: 1 })
+
+    expect(await card.readStatus()).toEqual(
+      expect.objectContaining({
+        shortValue: undefined,
+      })
+    )
+
+    expect(await card.readLongObject()).toEqual({ a: 1 })
+  })
+
+  it('can remove a card using #removeCard', async () => {
+    const card = new MemoryCard()
+      .insertCard('abc', Uint8Array.of(1, 2, 3))
+      .removeCard()
+
+    expect(await card.readStatus()).toEqual({
+      present: false,
+    })
+  })
+
+  it('fails to write a short value when there is no card', async () => {
+    await expect(new MemoryCard().writeShortValue('abc')).rejects.toThrow(
+      'cannot write short value when no card is present'
+    )
+  })
+
+  it('fails to write a long value when there is no card', async () => {
+    await expect(new MemoryCard().writeLongObject({})).rejects.toThrow(
+      'cannot write long value when no card is present'
+    )
+  })
+
+  it('gets undefined when reading an object when no long value is set', async () => {
+    expect(await new MemoryCard().insertCard().readLongObject()).toBeUndefined()
+  })
+})

--- a/src/utils/Card.ts
+++ b/src/utils/Card.ts
@@ -1,0 +1,220 @@
+import { Optional } from '@votingworks/ballot-encoder'
+import { toByteArray, fromByteArray } from 'base64-js'
+import { CardAPI } from '../config/types'
+import fetchJSON from './fetchJSON'
+
+/**
+ * Defines the API for accessing a smart card reader.
+ */
+export interface Card {
+  /**
+   * Reads basic information about the card, including whether one is present,
+   * what its short value is and whether it has a long value.
+   */
+  readStatus(): Promise<CardAPI>
+
+  /**
+   * Reads the long value as an object, or `undefined` if there is no long
+   * value.
+   */
+  readLongObject<T>(): Promise<Optional<T>>
+
+  /**
+   * Reads the long value as binary data, or `undefined` if there is no long
+   * value.
+   */
+  readLongUint8Array(): Promise<Optional<Uint8Array>>
+
+  /**
+   * Writes a new short value to the card.
+   */
+  writeShortValue(value: string): Promise<void>
+
+  /**
+   * Writes a new long value as a serialized object.
+   */
+  writeLongObject<T>(value: T): Promise<void>
+
+  /**
+   * Writes binary data to the long value.
+   */
+  writeLongUint8Array(value: Uint8Array): Promise<void>
+}
+
+/**
+ * Implements the `Card` API by accessing it through a web service.
+ */
+export class WebServiceCard implements Card {
+  /**
+   * Reads basic information about the card, including whether one is present,
+   * what its short value is and whether it has a long value.
+   */
+  public async readStatus(): Promise<CardAPI> {
+    return await fetchJSON<CardAPI>('/card/read')
+  }
+
+  /**
+   * Reads the long value as an object, or `undefined` if there is no long
+   * value.
+   */
+  public async readLongObject<T>(): Promise<Optional<T>> {
+    const response = await fetch('/card/read_long')
+    const { longValue } = await response.json()
+    return longValue ? JSON.parse(longValue) : undefined
+  }
+
+  /**
+   * Reads the long value as binary data, or `undefined` if there is no long
+   * value.
+   */
+  public async readLongUint8Array(): Promise<Optional<Uint8Array>> {
+    const response = await fetch('/card/read_long_b64')
+    const { longValue } = await response.json()
+    return longValue ? toByteArray(longValue) : undefined
+  }
+
+  /**
+   * Writes a new short value to the card.
+   */
+  public async writeShortValue(value: string): Promise<void> {
+    await fetch('/card/write', {
+      method: 'post',
+      body: value,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  /**
+   * Writes a new long value as a serialized object.
+   */
+  public async writeLongObject<T>(value: T): Promise<void> {
+    await this.writeLongUint8Array(
+      new TextEncoder().encode(JSON.stringify(value))
+    )
+  }
+
+  /**
+   * Writes binary data to the long value.
+   */
+  public async writeLongUint8Array(value: Uint8Array): Promise<void> {
+    const longValueBase64 = fromByteArray(value)
+    const formData = new FormData()
+
+    formData.append('long_value', longValueBase64)
+
+    await fetch('/card/write_long_b64', {
+      method: 'post',
+      body: formData,
+    })
+  }
+}
+
+/**
+ * Implements the `Card` API with an in-memory implementation.
+ */
+export class MemoryCard implements Card {
+  private present = false
+  private shortValue?: string
+  private longValue?: Uint8Array
+
+  /**
+   * Reads basic information about the card, including whether one is present,
+   * what its short value is and whether it has a long value.
+   */
+  public async readStatus(): Promise<CardAPI> {
+    const { present, shortValue } = this
+
+    if (present) {
+      const longValueExists = typeof this.longValue !== 'undefined'
+
+      return {
+        present,
+        shortValue,
+        longValueExists,
+      }
+    } else {
+      return { present }
+    }
+  }
+
+  /**
+   * Reads the long value as an object, or `undefined` if there is no long
+   * value.
+   */
+  public async readLongObject<T>(): Promise<Optional<T>> {
+    const { longValue } = this
+
+    if (!longValue) {
+      return
+    }
+
+    return JSON.parse(new TextDecoder().decode(longValue))
+  }
+
+  /**
+   * Reads the long value as binary data, or `undefined` if there is no long
+   * value.
+   */
+  public async readLongUint8Array(): Promise<Optional<Uint8Array>> {
+    return this.longValue
+  }
+
+  /**
+   * Writes a new short value to the card.
+   */
+  public async writeShortValue(value: string): Promise<void> {
+    if (!this.present) {
+      throw new Error('cannot write short value when no card is present')
+    }
+
+    this.shortValue = value
+  }
+
+  /**
+   * Writes a new long value as a serialized object.
+   */
+  public async writeLongObject<T>(value: T): Promise<void> {
+    await this.writeLongUint8Array(
+      new TextEncoder().encode(JSON.stringify(value))
+    )
+  }
+
+  /**
+   * Writes binary data to the long value.
+   */
+  public async writeLongUint8Array(value: Uint8Array): Promise<void> {
+    if (!this.present) {
+      throw new Error('cannot write long value when no card is present')
+    }
+
+    this.longValue = Uint8Array.from(value)
+  }
+
+  /**
+   * Removes the simulated in-memory card.
+   */
+  public removeCard(): this {
+    this.present = false
+    this.shortValue = undefined
+    this.longValue = undefined
+    return this
+  }
+
+  /**
+   * Inserts a simulated in-memory card with specified long and short values.
+   */
+  public insertCard<T>(
+    shortValue?: string,
+    longValue?: T | string | Uint8Array
+  ): this {
+    this.shortValue = shortValue
+    this.longValue =
+      typeof longValue === 'undefined'
+        ? undefined
+        : longValue instanceof Uint8Array
+        ? Uint8Array.from(longValue)
+        : new TextEncoder().encode(JSON.stringify(longValue))
+    this.present = true
+    return this
+  }
+}

--- a/src/utils/Card.ts
+++ b/src/utils/Card.ts
@@ -125,7 +125,8 @@ export class MemoryCard implements Card {
     const { present, shortValue } = this
 
     if (present) {
-      const longValueExists = typeof this.longValue !== 'undefined'
+      const longValueExists =
+        typeof this.longValue !== 'undefined' && this.longValue.length > 0
 
       return {
         present,

--- a/src/utils/Storage.test.ts
+++ b/src/utils/Storage.test.ts
@@ -1,0 +1,96 @@
+import { LocalStorage, MemoryStorage } from './Storage'
+
+describe('LocalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('uses local storage as the backing store', () => {
+    new LocalStorage<{ a: { b: string } }>().set('a', { b: 'c' })
+    expect(JSON.parse(window.localStorage.getItem('a') || '')).toEqual({
+      b: 'c',
+    })
+
+    window.localStorage.setItem('b', JSON.stringify({ a: 1 }))
+    expect(new LocalStorage<{ b: { a: number } }>().get('b')).toEqual({ a: 1 })
+  })
+
+  it('fails if the underlying value is not JSON', () => {
+    window.localStorage.setItem('a', 'this is not JSON')
+    expect(() => new LocalStorage<{ a: object }>().get('a')).toThrowError(
+      /JSON/
+    )
+  })
+
+  it('can remove a value', () => {
+    const storage = new LocalStorage<{ a: object }>()
+
+    expect(storage.get('a')).toBeUndefined()
+    window.localStorage.setItem('a', JSON.stringify({}))
+    expect(storage.get('a')).toBeDefined()
+    storage.remove('a')
+    expect(storage.get('a')).toBeUndefined()
+  })
+
+  it('can clear all values', () => {
+    const storage = new LocalStorage<{ a: object; b: object }>()
+
+    window.localStorage.setItem('a', JSON.stringify({}))
+    window.localStorage.setItem('b', JSON.stringify({}))
+    storage.clear()
+    expect(storage.get('a')).toBeUndefined()
+    expect(storage.get('b')).toBeUndefined()
+  })
+
+  it('serializes values as they are put in storage', () => {
+    const storage = new LocalStorage<{ a: object }>()
+    const object = { b: 1 }
+
+    storage.set('a', object)
+    object.b = 2
+
+    expect(storage.get('a')).toEqual({ b: 1 })
+  })
+})
+
+describe('MemoryStorage', () => {
+  it('can be initialized with data', () => {
+    const storage = new MemoryStorage<{ a: object; b: object; c: object }>({
+      a: { c: 1 },
+      b: { d: 2 },
+    })
+
+    expect(storage.get('a')).toEqual({ c: 1 })
+    expect(storage.get('b')).toEqual({ d: 2 })
+    expect(storage.get('c')).toBeUndefined()
+  })
+
+  it('can remove a value', () => {
+    const storage = new MemoryStorage<{ a: object }>()
+
+    storage.set('a', {})
+    expect(storage.get('a')).toBeDefined()
+    storage.remove('a')
+    expect(storage.get('a')).toBeUndefined()
+  })
+
+  it('can clear all values', () => {
+    const storage = new MemoryStorage<{ a: object; b: object }>()
+
+    storage.set('a', {})
+    storage.set('b', {})
+    storage.clear()
+    expect(storage.get('a')).toBeUndefined()
+    expect(storage.get('b')).toBeUndefined()
+  })
+
+  it('serializes values as they are put in storage', () => {
+    const storage = new MemoryStorage<{ a: object }>()
+    const object = { b: 1 }
+
+    storage.set('a', object)
+    object.b = 2
+
+    expect(storage.get('a')).toEqual({ b: 1 })
+  })
+})

--- a/src/utils/Storage.ts
+++ b/src/utils/Storage.ts
@@ -60,7 +60,12 @@ export class LocalStorage<M extends Serializable> implements Storage<M> {
    * Removes an object in storage by key.
    */
   public remove<K extends keyof M>(key: K): void {
-    window.localStorage.removeItem(key as string)
+    /* istanbul ignore next - turn this into type assertion with TypeScript 3.7 */
+    if (typeof key !== 'string') {
+      throw new Error(`localStorage keys must be strings, but was given ${key}`)
+    }
+
+    window.localStorage.removeItem(key)
   }
 
   /**

--- a/src/utils/Storage.ts
+++ b/src/utils/Storage.ts
@@ -1,0 +1,128 @@
+// TODO: define a type that's actually serializable
+export type Serializable = object
+
+/**
+ * Describes the API for application-level persistant storage. Values must be
+ * objects that can be persisted via JSON.stringify and JSON.parse.
+ */
+export interface Storage<M extends Serializable> {
+  /**
+   * Gets an object from storage by key.
+   */
+  get<K extends keyof M>(key: K): M[K] | undefined
+
+  /**
+   * Sets an object in storage by key.
+   */
+  set<K extends keyof M>(key: K, value: M[K]): void
+
+  /**
+   * Removes an object in storage by key.
+   */
+  remove<K extends keyof M>(key: K): void
+
+  /**
+   * Clears all objects out of storage.
+   */
+  clear(): void
+}
+
+/**
+ * Implements the storage API using `localStorage` as the backing store.
+ */
+export class LocalStorage<M extends Serializable> implements Storage<M> {
+  /**
+   * Gets an object from storage by key.
+   */
+  public get<K extends keyof M>(key: K): M[K] | undefined {
+    /* istanbul ignore next - turn this into type assertion with TypeScript 3.7 */
+    if (typeof key !== 'string') {
+      throw new Error(`localStorage keys must be strings, but was given ${key}`)
+    }
+
+    const value = window.localStorage.getItem(key)
+    return value ? JSON.parse(value) : undefined
+  }
+
+  /**
+   * Sets an object in storage by key.
+   */
+  public set<K extends keyof M>(key: K, value: M[K]): void {
+    /* istanbul ignore next - turn this into type assertion with TypeScript 3.7 */
+    if (typeof key !== 'string') {
+      throw new Error(`localStorage keys must be strings, but was given ${key}`)
+    }
+
+    window.localStorage.setItem(key, JSON.stringify(value))
+  }
+
+  /**
+   * Removes an object in storage by key.
+   */
+  public remove<K extends keyof M>(key: K): void {
+    window.localStorage.removeItem(key as string)
+  }
+
+  /**
+   * Clears all objects out of storage.
+   */
+  public clear(): void {
+    window.localStorage.clear()
+  }
+}
+
+/**
+ * Implements the storage API for storing objects in memory. Data stored in
+ * this object only lasts as long as the program runs.
+ */
+export class MemoryStorage<M extends Serializable> implements Storage<M> {
+  private data = new Map<keyof M, string>()
+
+  /**
+   * @param initial data to load into storage
+   */
+  public constructor(initial?: Partial<M>) {
+    if (initial) {
+      for (const key in initial) {
+        /* istanbul ignore else */
+        if (Object.prototype.hasOwnProperty.call(initial, key)) {
+          this.set(key, initial[key] as M[keyof M])
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets an object from storage by key.
+   */
+  public get<K extends keyof M>(key: K): M[K] | undefined {
+    const serialized = this.data.get(key)
+
+    if (typeof serialized === 'undefined') {
+      return serialized
+    }
+
+    return JSON.parse(serialized)
+  }
+
+  /**
+   * Sets an object in storage by key.
+   */
+  public set<K extends keyof M>(key: K, value: M[K]): void {
+    this.data.set(key, JSON.stringify(value))
+  }
+
+  /**
+   * Removes an object in storage by key.
+   */
+  public remove<K extends keyof M>(key: K): void {
+    this.data.delete(key)
+  }
+
+  /**
+   * Clears all objects out of storage.
+   */
+  public clear(): void {
+    this.data.clear()
+  }
+}

--- a/src/utils/polling.test.ts
+++ b/src/utils/polling.test.ts
@@ -1,0 +1,53 @@
+import { IntervalPoller } from './polling'
+
+describe('IntervalPoller', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  it('polls at a specific interval', () => {
+    const callback = jest.fn()
+
+    IntervalPoller.start(10, callback)
+
+    jest.advanceTimersByTime(10)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(10)
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores errors', () => {
+    IntervalPoller.start(10, () => {
+      throw new Error('callback error')
+    })
+
+    jest.advanceTimersByTime(50)
+  })
+
+  it('ignores async errors', () => {
+    IntervalPoller.start(10, async () => {
+      throw new Error('callback error')
+    })
+
+    jest.advanceTimersByTime(50)
+  })
+
+  it('cannot start a poller that is already started', () => {
+    const callback = jest.fn()
+    const poller = IntervalPoller.start(10, callback)
+
+    poller.start()
+    jest.advanceTimersByTime(10)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('can stop a poller', () => {
+    const callback = jest.fn()
+    const poller = IntervalPoller.start(10, callback)
+
+    poller.stop()
+    jest.advanceTimersByTime(10)
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -1,0 +1,45 @@
+export interface Poller {
+  stop(): void
+}
+
+export class IntervalPoller implements Poller {
+  private duration: number
+  private callback: () => Promise<void> | void
+  private interval?: ReturnType<typeof setTimeout>
+
+  public constructor(duration: number, callback: () => Promise<void> | void) {
+    this.duration = duration
+    this.callback = callback
+  }
+
+  public start(): this {
+    if (!this.interval) {
+      this.pollForever()
+    }
+
+    return this
+  }
+
+  public stop(): this {
+    window.clearInterval(this.interval)
+    this.interval = undefined
+    return this
+  }
+
+  private pollForever(): void {
+    this.interval = window.setInterval(async () => {
+      try {
+        await this.callback()
+      } catch (error) {
+        // ignore errors for now
+      }
+    }, this.duration)
+  }
+
+  public static start(
+    interval: number,
+    callback: () => Promise<void> | void
+  ): IntervalPoller {
+    return new IntervalPoller(interval, callback).start()
+  }
+}

--- a/test/helpers/election.ts
+++ b/test/helpers/election.ts
@@ -25,21 +25,27 @@ export const defaultBallotStyleId = election.ballotStyles[0].id
 export const altPrecinctId = election.precincts[1].id
 export const altBallotStyleId = election.ballotStyles[1].id
 
-export const presidentContest = electionSample.contests.find(
-  c => c.title === 'President and Vice-President' && c.seats === 1
+export const presidentContest = election.contests.find(
+  c =>
+    c.type === 'candidate' &&
+    c.title === 'President and Vice-President' &&
+    c.seats === 1
 ) as CandidateContest
 
-export const countyCommissionersContest = electionSample.contests.find(
-  c => c.title === 'County Commissioners' && c.seats === 4
+export const countyCommissionersContest = election.contests.find(
+  c =>
+    c.type === 'candidate' &&
+    c.title === 'County Commissioners' &&
+    c.seats === 4
 ) as CandidateContest
 
-export const measure102Contest = electionSample.contests.find(
+export const measure102Contest = election.contests.find(
   c =>
     c.title === 'Measure 102: Vehicle Abatement Program' && c.type === 'yesno'
 ) as YesNoContest
 
-export const singleSeatContestWithWriteIn = electionSample.contests.find(
-  c => !!c.allowWriteIns && c.seats === 1
+export const singleSeatContestWithWriteIn = election.contests.find(
+  c => c.type === 'candidate' && !!c.allowWriteIns && c.seats === 1
 ) as CandidateContest
 
 export const voterContests = getContests({

--- a/test/helpers/election.ts
+++ b/test/helpers/election.ts
@@ -62,8 +62,6 @@ export const voterContests = getContests({
   election,
 })
 
-export const electionAsString = JSON.stringify(election)
-
 export const setElectionInStorage = (storage: Storage<AppStorage>) => {
   storage.set(electionStorageKey, election)
 }

--- a/test/helpers/election.ts
+++ b/test/helpers/election.ts
@@ -10,7 +10,13 @@ import {
   getZeroTally,
 } from '../../src/utils/election'
 
-import { electionStorageKey, stateStorageKey } from '../../src/AppRoot'
+import {
+  electionStorageKey,
+  stateStorageKey,
+  AppStorage,
+  State,
+} from '../../src/AppRoot'
+import { Storage } from '../../src/utils/Storage'
 
 export const election = electionSample as Election
 export const contest0 = election.contests[0] as CandidateContest
@@ -58,12 +64,15 @@ export const voterContests = getContests({
 
 export const electionAsString = JSON.stringify(election)
 
-export const setElectionInLocalStorage = () => {
-  window.localStorage.setItem(electionStorageKey, electionAsString)
+export const setElectionInStorage = (storage: Storage<AppStorage>) => {
+  storage.set(electionStorageKey, election)
 }
 
-export const setStateInLocalStorage = (state = {}) => {
-  const defaultLiveState = {
+export const setStateInStorage = (
+  storage: Storage<AppStorage>,
+  state: Partial<State> = {}
+) => {
+  storage.set(stateStorageKey, {
     appMode: {
       name: 'VxMark',
       isVxMark: true,
@@ -73,14 +82,6 @@ export const setStateInLocalStorage = (state = {}) => {
     isLiveMode: true,
     isPollsOpen: true,
     tally: getZeroTally(election),
-  }
-  window.localStorage.setItem(
-    stateStorageKey,
-    JSON.stringify({
-      ...defaultLiveState,
-      ...state,
-    })
-  )
+    ...state,
+  })
 }
-
-export default {}

--- a/test/helpers/smartcards.ts
+++ b/test/helpers/smartcards.ts
@@ -6,9 +6,10 @@ import {
   vote,
   getContests,
   BallotType,
+  VotesDict,
 } from '@votingworks/ballot-encoder'
 import * as GLOBALS from '../../src/config/globals'
-import { CardAPI, CardPresentAPI, VoterCardData } from '../../src/config/types'
+import { VoterCardData } from '../../src/config/types'
 import utcTimestamp from '../../src/utils/utcTimestamp'
 
 const contest0 = election.contests[0] as CandidateContest
@@ -18,7 +19,7 @@ const contest1candidate0 = contest1.candidates[0]
 const altBallotStyleId = election.ballotStyles[1].id
 const altPrecinctId = election.precincts[1].id
 
-export const sampleVotes0 = vote(
+export const sampleVotes0: Readonly<VotesDict> = vote(
   getContests({
     ballotStyle: election.ballotStyles[0],
     election: election,
@@ -31,7 +32,7 @@ export const sampleVotes0 = vote(
   }
 )
 
-export const sampleVotes1 = vote(
+export const sampleVotes1: Readonly<VotesDict> = vote(
   getContests({
     ballotStyle: election.ballotStyles[0],
     election: election,
@@ -60,7 +61,7 @@ export const sampleVotes1 = vote(
   }
 )
 
-export const sampleVotes2 = vote(
+export const sampleVotes2: Readonly<VotesDict> = vote(
   getContests({
     ballotStyle: election.ballotStyles[0],
     election: election,
@@ -91,7 +92,7 @@ export const sampleVotes2 = vote(
   }
 )
 
-export const sampleVotes3 = vote(
+export const sampleVotes3: Readonly<VotesDict> = vote(
   getContests({
     ballotStyle: election.ballotStyles[0],
     election: election,
@@ -122,7 +123,7 @@ export const sampleVotes3 = vote(
   }
 )
 
-export const sampleBallot: CompletedBallot = {
+export const sampleBallot: Readonly<CompletedBallot> = {
   ballotId: 'test-ballot-id',
   ballotStyle: election.ballotStyles[0],
   election,
@@ -132,46 +133,24 @@ export const sampleBallot: CompletedBallot = {
   ballotType: BallotType.Standard,
 }
 
-export const noCard: CardAPI = {
-  present: false,
-}
+export const adminCard = JSON.stringify({
+  t: 'clerk',
+  h: 'abcd',
+})
 
-export const adminCard: CardPresentAPI = {
-  present: true,
-  longValueExists: true,
-  shortValue: JSON.stringify({
-    t: 'clerk',
-    h: 'abcd',
-  }),
-}
+export const pollWorkerCard = JSON.stringify({
+  t: 'pollworker',
+  h: 'abcd',
+})
 
-export const pollWorkerCard: CardPresentAPI = {
-  present: true,
-  shortValue: JSON.stringify({
-    t: 'pollworker',
-    h: 'abcd',
-  }),
-}
-
-type CreateVoterCardConfig = Partial<VoterCardData> & {
-  longValueExists?: boolean
-}
-
-export const createVoterCard = (
-  config: CreateVoterCardConfig = {}
-): CardPresentAPI => {
-  const { longValueExists, ...cardData } = config
-  return {
-    present: true,
-    longValueExists,
-    shortValue: JSON.stringify({
-      t: 'voter',
-      c: utcTimestamp(),
-      pr: election.precincts[0].id,
-      bs: election.ballotStyles[0].id,
-      ...cardData,
-    }),
-  }
+export const createVoterCard = (cardData: Partial<VoterCardData> = {}) => {
+  return JSON.stringify({
+    t: 'voter',
+    c: utcTimestamp(),
+    pr: election.precincts[0].id,
+    bs: election.ballotStyles[0].id,
+    ...cardData,
+  })
 }
 
 export const getNewVoterCard = () => createVoterCard()
@@ -190,17 +169,6 @@ export const getVoidedVoterCard = () =>
 export const getExpiredVoterCard = () =>
   createVoterCard({
     c: utcTimestamp() - GLOBALS.CARD_EXPIRATION_SECONDS,
-  })
-
-export const getExpiredVoterCardWithVotes = () =>
-  createVoterCard({
-    c: utcTimestamp() - GLOBALS.CARD_EXPIRATION_SECONDS,
-    longValueExists: true,
-  })
-
-export const getVoterCardWithVotes = () =>
-  createVoterCard({
-    longValueExists: true,
   })
 
 export const getUsedVoterCard = () =>


### PR DESCRIPTION
This allows both `App` and `AppRoot` to be agnostic to whether they're running in the sample app or not. The basic idea is that the app works through mocked card and storage objects in the sample app and real ones otherwise. This will make it easier to, in the future, move away from local storage entirely and onto a backend service.
