### PR TITLE
chore: forward BMD web port

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,12 @@
   "scss.validate": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "remote.SSH.defaultForwardedPorts": [
+    {
+      "localPort": 3000,
+      "name": "BMD Web",
+      "remotePort": 3000
+    }
+  ]
 }


### PR DESCRIPTION
This makes it so you don't have to manually configure it in VS Code.
