### PR TITLE
refactor: rewrite `assertDefined` as an assertion function

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
   },
   "resolutions": {
     "**/@typescript-eslint/eslint-plugin": "2.14.0",
-    "**/@typescript-eslint/parser": "2.14.0"
+    "**/@typescript-eslint/parser": "2.14.0",
+    "**/@babel/parser": "7.7.7"
   }
 }

--- a/src/utils/Storage.ts
+++ b/src/utils/Storage.ts
@@ -1,3 +1,5 @@
+import assert from './assert'
+
 // TODO: define a type that's actually serializable
 export type Serializable = object
 
@@ -35,11 +37,7 @@ export class LocalStorage<M extends Serializable> implements Storage<M> {
    * Gets an object from storage by key.
    */
   public get<K extends keyof M>(key: K): M[K] | undefined {
-    /* istanbul ignore next - turn this into type assertion with TypeScript 3.7 */
-    if (typeof key !== 'string') {
-      throw new Error(`localStorage keys must be strings, but was given ${key}`)
-    }
-
+    assert(typeof key === 'string')
     const value = window.localStorage.getItem(key)
     return value ? JSON.parse(value) : undefined
   }
@@ -48,11 +46,7 @@ export class LocalStorage<M extends Serializable> implements Storage<M> {
    * Sets an object in storage by key.
    */
   public set<K extends keyof M>(key: K, value: M[K]): void {
-    /* istanbul ignore next - turn this into type assertion with TypeScript 3.7 */
-    if (typeof key !== 'string') {
-      throw new Error(`localStorage keys must be strings, but was given ${key}`)
-    }
-
+    assert(typeof key === 'string')
     window.localStorage.setItem(key, JSON.stringify(value))
   }
 
@@ -60,11 +54,7 @@ export class LocalStorage<M extends Serializable> implements Storage<M> {
    * Removes an object in storage by key.
    */
   public remove<K extends keyof M>(key: K): void {
-    /* istanbul ignore next - turn this into type assertion with TypeScript 3.7 */
-    if (typeof key !== 'string') {
-      throw new Error(`localStorage keys must be strings, but was given ${key}`)
-    }
-
+    assert(typeof key === 'string')
     window.localStorage.removeItem(key)
   }
 

--- a/src/utils/assert.test.ts
+++ b/src/utils/assert.test.ts
@@ -1,0 +1,20 @@
+import assert from './assert'
+
+it('throws when given literal false', () => {
+  expect(() => assert(false)).toThrowError()
+})
+
+it('does not throw when given literal true', () => {
+  expect(() => assert(true)).not.toThrowError()
+})
+
+it('asserts for type checking purposes that the statement is true', () => {
+  // Set up a value whose type is not known.
+  const a: unknown = 1
+
+  // Assert that it is a number.
+  assert(typeof a === 'number')
+
+  // This would not type check if TypeScript considered `a` to be `unknown`.
+  a.toFixed()
+})

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,18 @@
+/**
+ * Asserts for both runtime and type-check purposes that `condition` is true.
+ *
+ * @example
+ *
+ * function len(array: unknown): number {
+ *   assert(Array.isArray(array))
+ *   return array.length
+ * }
+ */
+export default function assert(
+  condition: boolean,
+  message = 'assertion failed'
+): asserts condition {
+  if (!condition) {
+    throw new Error(message)
+  }
+}

--- a/src/utils/assertDefined.test.ts
+++ b/src/utils/assertDefined.test.ts
@@ -1,12 +1,11 @@
 import assertDefined from './assertDefined'
 
-test('returns a falsy argument when it is not null or undefined', () => {
-  expect(assertDefined(0)).toBe(0)
+test('does not throw when given 0', () => {
+  expect(() => assertDefined(0)).not.toThrowError()
 })
 
-test('returns an object argument', () => {
-  const obj = {}
-  expect(assertDefined(obj)).toBe(obj)
+test('does not throw when given an empty object', () => {
+  expect(() => assertDefined({})).not.toThrowError()
 })
 
 test('throws when given null', () => {
@@ -18,18 +17,28 @@ test('throws when given undefined', () => {
   expect(() => assertDefined(undefined)).toThrowError()
 })
 
+// This isn't a runtime check, really. It just ensures TypeScript is happy.
 test('refines the type of the argument by removing null', () => {
-  // This isn't a runtime check, really. It just ensures TypeScript is happy.
-  const original: string | null = 'a string'
-  const refined: string = assertDefined(original)
-  expect(refined).toBe(original)
+  // Declare that `value` might be `null`.
+  const value: string | null = 'a string'
+
+  // Assert that it isn't `null`.
+  assertDefined(value)
+
+  // Use it as though it isn't `null`.
+  value.toUpperCase()
 })
 
+// This isn't a runtime check, really. It just ensures TypeScript is happy.
 test('refines the type of the argument by removing undefined', () => {
-  // This isn't a runtime check, really. It just ensures TypeScript is happy.
-  const original: string | undefined = 'a string'
-  const refined: string = assertDefined(original)
-  expect(refined).toBe(original)
+  // Declare that `value` might be `undefined`.
+  const value: string | undefined = 'a string'
+
+  // Assert that it isn't `undefined`.
+  assertDefined(value)
+
+  // Use it as though it isn't `undefined`.
+  value.toUpperCase()
 })
 
 test('can throw with a custom message', () => {

--- a/src/utils/assertDefined.ts
+++ b/src/utils/assertDefined.ts
@@ -1,9 +1,9 @@
-export default function assertDefined(
-  value: unknown,
+import assert from './assert'
+
+export default function assertDefined<T>(
+  value: T | null | undefined,
   message = 'value expected to be defined but was not'
-): asserts value {
+): asserts value is T {
   // eslint-disable-next-line no-restricted-syntax
-  if (value === null || value === undefined) {
-    throw new Error(message)
-  }
+  assert(value !== null && value !== undefined, message)
 }

--- a/src/utils/assertDefined.ts
+++ b/src/utils/assertDefined.ts
@@ -1,11 +1,9 @@
-export default function assertDefined<T>(
-  value: T | null | undefined,
+export default function assertDefined(
+  value: unknown,
   message = 'value expected to be defined but was not'
-): T {
+): asserts value {
   // eslint-disable-next-line no-restricted-syntax
   if (value === null || value === undefined) {
     throw new Error(message)
   }
-
-  return value
 }

--- a/src/utils/buildBallot.ts
+++ b/src/utils/buildBallot.ts
@@ -26,9 +26,12 @@ export default function buildBallot({
   votes: VotesDict
 }): CompletedBallot {
   const ballotId = randomBase64()
-  const ballotStyle = assertDefined(getBallotStyle({ ballotStyleId, election }))
+  const ballotStyle = getBallotStyle({ ballotStyleId, election })
   const ballotType = BallotType.Standard
-  const precinct = assertDefined(getPrecinctById({ precinctId, election }))
+  const precinct = getPrecinctById({ precinctId, election })
+
+  assertDefined(ballotStyle)
+  assertDefined(precinct)
 
   return {
     ballotId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,12 +372,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
-  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
-
-"@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.7.7":
+"@babel/parser@7.7.7", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.7.7":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.7.tgz#1b886595419cf92d811316d5b715a53ff38b4937"
   integrity sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==


### PR DESCRIPTION
The `asserts X` return type syntax is new in TypeScript 3.7. Pins `@babel/parser` to latest in order to make sure everything can parse it.
