### PR TITLE
style(lint): disallow `null` with a custom error message

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,14 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off', // Want to use it, but it requires return types for all built-in React lifecycle methods.
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
-    'import/extensions': 'off'
+    'import/extensions': 'off',
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'Literal[value=null]',
+        message: '`null` is generally not what you want outside of React classes, use `undefined` instead'
+      }
+    ],
   },
   overrides: [
     {

--- a/src/components/TestMode.tsx
+++ b/src/components/TestMode.tsx
@@ -13,6 +13,7 @@ interface Props {
 }
 
 const TestMode = ({ isLiveMode }: Props) =>
+  // eslint-disable-next-line no-restricted-syntax
   isLiveMode ? null : (
     <TestingModeContainer warning bold warningIcon center>
       Testing Mode

--- a/src/utils/ScreenReader.test.ts
+++ b/src/utils/ScreenReader.test.ts
@@ -38,6 +38,7 @@ describe('AriaScreenReader', () => {
 
     // Can't do `node.textContent = null` because it gets coerced to "null".
     Object.defineProperty(node, 'textContent', {
+      // eslint-disable-next-line no-restricted-syntax
       value: null,
     })
 

--- a/src/utils/assertDefined.test.ts
+++ b/src/utils/assertDefined.test.ts
@@ -10,6 +10,7 @@ test('returns an object argument', () => {
 })
 
 test('throws when given null', () => {
+  // eslint-disable-next-line no-restricted-syntax
   expect(() => assertDefined(null)).toThrowError()
 })
 

--- a/src/utils/assertDefined.ts
+++ b/src/utils/assertDefined.ts
@@ -2,6 +2,7 @@ export default function assertDefined<T>(
   value: T | null | undefined,
   message = 'value expected to be defined but was not'
 ): T {
+  // eslint-disable-next-line no-restricted-syntax
   if (value === null || value === undefined) {
     throw new Error(message)
   }

--- a/src/utils/isJSON.test.ts
+++ b/src/utils/isJSON.test.ts
@@ -5,7 +5,7 @@ import isJSON, { isJSONStrict } from './isJSON'
 
 it('perform isJSON verifications', () => {
   expect(isJSON('asdada[]asdadada sd asdasda das das')).toBeFalsy()
-  expect(isJSON(null)).toBeFalsy()
+  expect(isJSON(null)).toBeFalsy() // eslint-disable-line no-restricted-syntax
   expect(isJSON(false)).toBeFalsy()
   expect(isJSON('')).toBeFalsy()
   expect(isJSON('normal string')).toBeFalsy()


### PR DESCRIPTION
This brings back the functionality of the `no-null` eslint pugin using the built-in `no-restricted-syntax` rule. See the selector docs here: https://eslint.org/docs/developer-guide/selectors and the rule docs here: https://eslint.org/docs/rules/no-restricted-syntax.

The downside is that we can't ignore _only_ the "no null" part of `no-restricted-syntax`, but I don't think it'll be a problem. If is is, we can revisit this with a custom rule that'd be pretty trivial.
