### PR TITLE
fix: don't allow double-tapping write-in "Accept"

### DIFF
--- a/src/components/CandidateContest.test.tsx
+++ b/src/components/CandidateContest.test.tsx
@@ -129,7 +129,6 @@ describe('supports write-in candidates', () => {
     getByText('Write-In Candidate')
     typeKeysInVirtualKeyboard(getByText, 'LIZARD PEOPLE')
     fireEvent.click(getByText('Accept'))
-    jest.runOnlyPendingTimers() // Handle Delay when clicking "Accept"
     expect(queryByText('Write-In Candidate')).toBeFalsy()
 
     expect(updateVote).toHaveBeenCalledWith(contest.id, [
@@ -156,7 +155,6 @@ describe('supports write-in candidates', () => {
     )
     getByText('You have entered 37 of maximum 40 characters.')
     fireEvent.click(getByText('Cancel'))
-    jest.runOnlyPendingTimers() // Handle Delay when clicking "Cancel"
     expect(queryByText('Write-In Candidate')).toBeFalsy()
   })
 
@@ -184,7 +182,6 @@ describe('supports write-in candidates', () => {
         .hasAttribute('disabled')
     ).toBe(true)
     fireEvent.click(getByText('Accept'))
-    jest.runOnlyPendingTimers() // Handle Delay when clicking "Accept"
     expect(queryByText('Write-In Candidate')).toBeFalsy()
 
     expect(updateVote).toHaveBeenCalledWith(contest.id, [

--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -311,19 +311,12 @@ class CandidateContest extends React.Component<Props, State> {
       },
     ])
     this.setState({ writeInCandidateName: '' })
-
-    // Delay to avoid passing tap to next screen
-    window.setTimeout(() => {
-      this.toggleWriteInCandidateModal(false)
-    }, 200)
+    this.toggleWriteInCandidateModal(false)
   }
 
   public cancelWriteInCandidateModal = () => {
     this.setState({ writeInCandidateName: '' })
-    // Delay to avoid passing tap to next screen
-    window.setTimeout(() => {
-      this.toggleWriteInCandidateModal(false)
-    }, 200)
+    this.toggleWriteInCandidateModal(false)
   }
 
   public toggleWriteInCandidateModal = (writeInCandateModalIsOpen: boolean) => {


### PR DESCRIPTION
This was only reproducible with touch events (i.e. tapping) rather than click events. The fix is simply to remove the timeout that we previously needed but no longer do after the changes made to fix tap/click handling a while ago. We could also have added an explicit guard, but as this is now synchronous I didn't deem it worth the effort.

Fixes #1028
