### PR TITLE
refactor: consolidate `withMarkup` helpers

### DIFF
--- a/src/AppPrintOnly.test.tsx
+++ b/src/AppPrintOnly.test.tsx
@@ -22,6 +22,8 @@ import {
   createVoterCard,
 } from '../test/helpers/smartcards'
 
+import withMarkup from '../test/helpers/withMarkup'
+
 import { printerMessageTimeoutSeconds } from './pages/PrintOnlyScreen'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
@@ -52,16 +54,8 @@ it('VxPrintOnly flow', async () => {
   const { getAllByText, getByLabelText, getByText, getByTestId } = render(
     <App storage={storage} card={card} />
   )
-  // Query by text which includes markup.
-  // https://stackoverflow.com/questions/55509875/how-to-query-by-text-string-which-contains-html-tags-using-react-testing-library
-  const getAllByTextWithMarkup = (text: string) =>
-    getAllByText((content, node) => {
-      const hasText = (node: HTMLElement) => node.textContent === text
-      const childrenDontHaveText = Array.from(node.children).every(
-        child => !hasText(child as HTMLElement)
-      )
-      return hasText(node) && childrenDontHaveText
-    })
+
+  const getAllByTextWithMarkup = withMarkup(getAllByText)
 
   card.removeCard()
   advanceTimers()

--- a/test/helpers/withMarkup.ts
+++ b/test/helpers/withMarkup.ts
@@ -2,15 +2,16 @@
 
 import { MatcherFunction } from '@testing-library/react'
 
-type Query = (f: MatcherFunction) => HTMLElement
+type Query<T> = (f: MatcherFunction) => T
 
-const withMarkup = (query: Query) => (text: string): HTMLElement =>
+const hasText = (text: string, node: HTMLElement) => node.textContent === text
+
+const withMarkup = <T>(query: Query<T>) => (text: string): T =>
   query((content: string, node: HTMLElement) => {
-    const hasText = (node: HTMLElement) => node.textContent === text
     const childrenDontHaveText = Array.from(node.children).every(
-      child => !hasText(child as HTMLElement)
+      child => !hasText(text, child as HTMLElement)
     )
-    return hasText(node) && childrenDontHaveText
+    return hasText(text, node) && childrenDontHaveText
   })
 
 export default withMarkup


### PR DESCRIPTION
This adapts the existing `withMarkup` to be flexible about the type returned by its query, allowing single or multiple elements to be found in a type-safe way.
