### PR TITLE
Setup error screens

### DIFF
--- a/src/APICardCatch.test.tsx
+++ b/src/APICardCatch.test.tsx
@@ -12,6 +12,7 @@ import {
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -21,8 +22,9 @@ beforeEach(() => {
 
 it('Cause "/card/read" API to catch', async () => {
   // Configure Machine
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
   setElectionInStorage(storage)
   setStateInStorage(storage)
 
@@ -32,7 +34,9 @@ it('Cause "/card/read" API to catch', async () => {
     .mockImplementation(() => {
       throw new Error('NOPE')
     })
-  const { getByText } = render(<App storage={storage} card={card} />)
+  const { getByText } = render(
+    <App card={card} hardware={hardware} storage={storage} />
+  )
 
   // Ensure card polling interval time is passed
   advanceTimers()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,7 @@ import { BrowserRouter, Route } from 'react-router-dom'
 import 'normalize.css'
 import './App.css'
 
-import FocusManager from './components/FocusManager'
-
-import AppRoot, { Props as AppRootProps, AppStorage } from './AppRoot'
+import memoize from './utils/memoize'
 import {
   ScreenReader,
   AriaScreenReader,
@@ -17,21 +15,25 @@ import {
 import { WebServiceCard } from './utils/Card'
 import { LocalStorage } from './utils/Storage'
 import { getUSEnglishVoice } from './utils/voices'
-import memoize from './utils/memoize'
 import getPrinter from './utils/printer'
+import { getHardware } from './utils/Hardware'
+
+import AppRoot, { Props as AppRootProps, AppStorage } from './AppRoot'
+import FocusManager from './components/FocusManager'
 
 window.oncontextmenu = (e: MouseEvent): void => {
   e.preventDefault()
 }
 
 export interface Props {
+  hardware?: AppRootProps['hardware']
+  card?: AppRootProps['card']
+  storage?: AppRootProps['storage']
+  printer?: AppRootProps['printer']
   tts?: {
     enabled: TextToSpeech
     disabled: TextToSpeech
   }
-  card?: AppRootProps['card']
-  storage?: AppRootProps['storage']
-  printer?: AppRootProps['printer']
 }
 
 const App = ({
@@ -42,6 +44,7 @@ const App = ({
   card = new WebServiceCard(),
   storage = new LocalStorage<AppStorage>(),
   printer = getPrinter(),
+  hardware = getHardware(),
 }: Props) => {
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false)
   const [screenReader, setScreenReader] = useState<ScreenReader>(
@@ -115,7 +118,6 @@ const App = ({
     },
     [screenReader]
   )
-
   return (
     <BrowserRouter>
       <FocusManager
@@ -129,8 +131,9 @@ const App = ({
           render={props => (
             <AppRoot
               card={card}
-              storage={storage}
               printer={printer}
+              hardware={hardware}
+              storage={storage}
               {...props}
             />
           )}

--- a/src/AppCardUnhappyPaths.test.tsx
+++ b/src/AppCardUnhappyPaths.test.tsx
@@ -20,25 +20,30 @@ import utcTimestamp from './utils/utcTimestamp'
 import { MemoryCard } from './utils/Card'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
+jest.setTimeout(20000) // TODO: Added after hardware polling added. Why?
 
 beforeEach(() => {
   window.location.href = '/'
 })
 
-it('VxMark+Print end-to-end flow', async () => {
+it('Display App Card Unhappy Paths', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
 
   card.removeCard()
 
   setElectionInStorage(storage)
   setStateInStorage(storage)
 
-  const { getByText } = render(<App storage={storage} card={card} />)
+  const { getByText } = render(
+    <App card={card} hardware={hardware} storage={storage} />
+  )
 
   // ====================== END CONTEST SETUP ====================== //
 

--- a/src/AppContestMultiSeat.test.tsx
+++ b/src/AppContestMultiSeat.test.tsx
@@ -13,6 +13,7 @@ import {
 import { MemoryCard } from './utils/Card'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -23,14 +24,15 @@ beforeEach(() => {
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
 
   setElectionInStorage(storage)
   setStateInStorage(storage)
 
   const { container, getByText, queryByText } = render(
-    <App storage={storage} card={card} />
+    <App card={card} hardware={hardware} storage={storage} />
   )
 
   // Insert Voter Card

--- a/src/AppContestSingleSeat.test.tsx
+++ b/src/AppContestSingleSeat.test.tsx
@@ -13,6 +13,7 @@ import {
 import { MemoryCard } from './utils/Card'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -23,13 +24,16 @@ beforeEach(() => {
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
 
   setElectionInStorage(storage)
   setStateInStorage(storage)
 
-  const { container, getByText } = render(<App storage={storage} card={card} />)
+  const { container, getByText } = render(
+    <App card={card} hardware={hardware} storage={storage} />
+  )
 
   // Insert Voter Card
   card.insertCard(getNewVoterCard())

--- a/src/AppContestWriteIn.test.tsx
+++ b/src/AppContestWriteIn.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { fireEvent, render, wait, within } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 
 import App from './App'
 
@@ -18,6 +17,7 @@ import { MemoryCard } from './utils/Card'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import fakePrinter from '../test/helpers/fakePrinter'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -28,9 +28,10 @@ beforeEach(() => {
 it('Single Seat Contest with Write In', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
   const printer = fakePrinter()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
 
   setElectionInStorage(storage)
   setStateInStorage(storage, {
@@ -38,7 +39,7 @@ it('Single Seat Contest with Write In', async () => {
   })
 
   const { container, getByText, queryByText, getByTestId } = render(
-    <App storage={storage} card={card} printer={printer} />
+    <App card={card} hardware={hardware} printer={printer} storage={storage} />
   )
   const getByTextWithMarkup = withMarkup(getByText)
 

--- a/src/AppContestYesNo.test.tsx
+++ b/src/AppContestYesNo.test.tsx
@@ -15,6 +15,7 @@ import {
 import { MemoryCard } from './utils/Card'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -25,14 +26,15 @@ beforeEach(() => {
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
 
   setElectionInStorage(storage)
   setStateInStorage(storage)
 
   const { getByText, queryByText, getByTestId } = render(
-    <App storage={storage} card={card} />
+    <App card={card} hardware={hardware} storage={storage} />
   )
 
   // Insert Voter Card

--- a/src/AppData.test.tsx
+++ b/src/AppData.test.tsx
@@ -25,6 +25,15 @@ describe('loads election', () => {
     getByText('Device Not Configured')
   })
 
+  it('from storage', () => {
+    const storage = new MemoryStorage<AppStorage>()
+    setElectionInStorage(storage)
+    setStateInStorage(storage)
+    const { getByText } = render(<App storage={storage} />)
+    getByText(election.title)
+    expect(storage.get(electionStorageKey)).toBeTruthy()
+  })
+
   it('sample app loads election and activates ballot', async () => {
     const storage = getSampleStorage()
     const { getAllByText, getByText } = render(<SampleApp storage={storage} />)
@@ -36,14 +45,5 @@ describe('loads election', () => {
     })
     expect(storage.get(electionStorageKey)).toBeTruthy()
     expect(storage.get(activationStorageKey)).toBeTruthy()
-  })
-
-  it('from storage', () => {
-    const storage = new MemoryStorage<AppStorage>()
-    setElectionInStorage(storage)
-    setStateInStorage(storage)
-    const { getByText } = render(<App storage={storage} />)
-    getByText(election.title)
-    expect(storage.get(electionStorageKey)).toBeTruthy()
   })
 })

--- a/src/AppEndToEnd.test.tsx
+++ b/src/AppEndToEnd.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { fireEvent, render, wait, within } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 import { advanceBy } from 'jest-date-mock'
 
 import { electionSample } from '@votingworks/ballot-encoder'
@@ -29,20 +28,23 @@ import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
 import fakePrinter from '../test/helpers/fakePrinter'
+import { MemoryHardware } from './utils/Hardware'
 
 beforeEach(() => {
   window.location.href = '/'
 })
 
-it('VxMark+Print end-to-end flow', async () => {
-  jest.useFakeTimers()
+jest.useFakeTimers()
+jest.setTimeout(20000) // TODO: Added after hardware polling added. Why?
 
-  const storage = new MemoryStorage<AppStorage>()
+it('VxMark+Print end-to-end flow', async () => {
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
   const printer = fakePrinter()
+  const storage = new MemoryStorage<AppStorage>()
   const writeLongUint8ArrayMock = jest.spyOn(card, 'writeLongUint8Array')
   const { getByLabelText, getByText, getByTestId } = render(
-    <App storage={storage} card={card} printer={printer} />
+    <App card={card} hardware={hardware} storage={storage} printer={printer} />
   )
   const getByTextWithMarkup = withMarkup(getByText)
 

--- a/src/AppMarkOnly.test.tsx
+++ b/src/AppMarkOnly.test.tsx
@@ -22,6 +22,7 @@ import {
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
+import { MemoryHardware } from './utils/Hardware'
 
 beforeEach(() => {
   window.location.href = '/'
@@ -30,10 +31,11 @@ beforeEach(() => {
 it('VxMarkOnly flow', async () => {
   jest.useFakeTimers()
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
   const { getByTestId, getByLabelText, getByText } = render(
-    <App storage={storage} card={card} />
+    <App card={card} hardware={hardware} storage={storage} />
   )
   const getByTextWithMarkup = withMarkup(getByText)
 

--- a/src/AppMarkVoterCardInvalid.test.tsx
+++ b/src/AppMarkVoterCardInvalid.test.tsx
@@ -17,26 +17,29 @@ import {
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
-
-jest.useFakeTimers()
+import { MemoryHardware } from './utils/Hardware'
 
 beforeEach(() => {
   window.location.href = '/'
 })
+
+jest.useFakeTimers()
+jest.setTimeout(20000) // TODO: Added after hardware polling added. Why?
 
 const idleScreenCopy =
   'This voting station has been inactive for more than 5 minutes.'
 
 describe('Mark Card Void when voter is idle too long', () => {
   it('Display expired card if card marked as voided', async () => {
-    const storage = new MemoryStorage<AppStorage>()
     const card = new MemoryCard()
+    const hardware = new MemoryHardware()
+    const storage = new MemoryStorage<AppStorage>()
 
     setElectionInStorage(storage)
     setStateInStorage(storage)
 
     const { getByText, queryByText } = render(
-      <App storage={storage} card={card} />
+      <App card={card} hardware={hardware} storage={storage} />
     )
 
     // Insert Voter card
@@ -88,13 +91,16 @@ describe('Mark Card Void when voter is idle too long', () => {
     // https://github.com/votingworks/bmd/issues/714
     fetchMock.get('/machine-id', () => JSON.stringify({ machineId: '1' }))
 
-    const storage = new MemoryStorage<AppStorage>()
     const card = new MemoryCard()
+    const hardware = new MemoryHardware()
+    const storage = new MemoryStorage<AppStorage>()
 
     setElectionInStorage(storage)
     setStateInStorage(storage)
 
-    const { getByText } = render(<App storage={storage} card={card} />)
+    const { getByText } = render(
+      <App card={card} hardware={hardware} storage={storage} />
+    )
 
     // Insert Voter card
     card.insertCard(getNewVoterCard())

--- a/src/AppPrintOnly.test.tsx
+++ b/src/AppPrintOnly.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { fireEvent, render, wait, within } from '@testing-library/react'
-import fetchMock from 'fetch-mock'
 import {
   electionSample,
   encodeBallot,
@@ -29,19 +28,22 @@ import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
 import fakePrinter from '../test/helpers/fakePrinter'
+import { MemoryHardware } from './utils/Hardware'
 
 beforeEach(() => {
   window.location.href = '/'
 })
 
-it('VxPrintOnly flow', async () => {
-  jest.useFakeTimers()
+jest.useFakeTimers()
+jest.setTimeout(20000) // TODO: Added after hardware polling added. Why?
 
-  const storage = new MemoryStorage<AppStorage>()
+it('VxPrintOnly flow', async () => {
   const card = new MemoryCard()
   const printer = fakePrinter()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
   const { getAllByText, getByLabelText, getByText, getByTestId } = render(
-    <App storage={storage} card={card} printer={printer} />
+    <App card={card} hardware={hardware} storage={storage} printer={printer} />
   )
 
   const getAllByTextWithMarkup = withMarkup(getAllByText)

--- a/src/AppRefresh.test.tsx
+++ b/src/AppRefresh.test.tsx
@@ -43,7 +43,6 @@ it('Refresh window and expect to be on same contest', async () => {
 
   // Go to First Contest
   await wait(() => fireEvent.click(getByText('Start Voting')))
-  advanceTimers()
 
   // ====================== END CONTEST SETUP ====================== //
 
@@ -58,7 +57,7 @@ it('Refresh window and expect to be on same contest', async () => {
 
   // advance time by CARD_LONG_VALUE_WRITE_DELAY to let background interval write to card
   advanceBy(1000)
-  advanceTimers()
+  await wait()
 
   unmount()
   ;({ getByText, unmount } = render(
@@ -69,6 +68,7 @@ it('Refresh window and expect to be on same contest', async () => {
 
   // App is on first contest
   await wait(() => getByText(presidentContest.title))
+
   // First candidate selected
   expect(getByText(candidate0).closest('button')!.dataset.selected).toBe('true')
 })

--- a/src/AppRefresh.test.tsx
+++ b/src/AppRefresh.test.tsx
@@ -15,6 +15,7 @@ import {
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -25,13 +26,16 @@ beforeEach(() => {
 it('Refresh window and expect to be on same contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
 
   setElectionInStorage(storage)
   setStateInStorage(storage)
 
-  let { getByText, unmount } = render(<App storage={storage} card={card} />)
+  let { getByText, unmount } = render(
+    <App card={card} hardware={hardware} storage={storage} />
+  )
 
   // Insert Voter Card
   card.insertCard(getNewVoterCard())
@@ -57,7 +61,9 @@ it('Refresh window and expect to be on same contest', async () => {
   advanceTimers()
 
   unmount()
-  ;({ getByText, unmount } = render(<App storage={storage} card={card} />))
+  ;({ getByText, unmount } = render(
+    <App card={card} hardware={hardware} storage={storage} />
+  ))
 
   advanceTimers()
 

--- a/src/AppSetupErrors.test.tsx
+++ b/src/AppSetupErrors.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { render, wait } from '@testing-library/react'
+
+import App from './App'
+import { AppStorage } from './AppRoot'
+import { MemoryHardware } from './utils/Hardware'
+import { MemoryStorage } from './utils/Storage'
+
+import { advanceTimers } from '../test/helpers/smartcards'
+
+import {
+  setElectionInStorage,
+  setStateInStorage,
+} from '../test/helpers/election'
+import withMarkup from '../test/helpers/withMarkup'
+import { VxPrintOnly } from './config/types'
+import { MemoryCard } from './utils/Card'
+
+jest.useFakeTimers()
+
+beforeEach(() => {
+  window.location.href = '/'
+})
+
+const card = new MemoryCard()
+const storage = new MemoryStorage<AppStorage>()
+
+const insertCardScreenText = 'Insert voter card to load ballot.'
+const lowBatteryErrorScreenText = 'No Power Detected and Battery is Low'
+const noPowerDetectedWarningText = 'No Power Detected.'
+
+describe('Displays setup warning messages and errors scrrens', () => {
+  it('Displays warning if Accessible Controller connection is lost', async () => {
+    const hardware = new MemoryHardware()
+    setElectionInStorage(storage)
+    setStateInStorage(storage)
+    const { getByText, queryByText } = render(
+      <App card={card} hardware={hardware} storage={storage} />
+    )
+    const accessibleControllerWarningText =
+      'Voting with an accessible controller is not currently available.'
+
+    // Start on VxMark Insert Card screen
+    getByText(insertCardScreenText)
+    expect(queryByText(accessibleControllerWarningText)).toBeFalsy()
+
+    // Disconnect Accessible Controller
+    hardware.setAccesssibleControllerConnected(false)
+    advanceTimers()
+    await wait(() => getByText(accessibleControllerWarningText))
+    getByText(insertCardScreenText)
+
+    // Reconnect Accessible Controller
+    hardware.setAccesssibleControllerConnected(true)
+    advanceTimers()
+    await wait(() => !queryByText(accessibleControllerWarningText))
+    getByText(insertCardScreenText)
+  })
+
+  it('Displays error screen if Card Reader connection is lost', async () => {
+    const hardware = new MemoryHardware()
+    setElectionInStorage(storage)
+    setStateInStorage(storage)
+    const { getByText } = render(
+      <App card={card} hardware={hardware} storage={storage} />
+    )
+
+    // Start on VxMark Insert Card screen
+    getByText(insertCardScreenText)
+
+    // Disconnect Card Reader
+    hardware.setCardReaderConnected(false)
+    advanceTimers()
+    await wait(() => getByText('Card Reader Not Detected'))
+
+    // Reconnect Card Reader
+    hardware.setCardReaderConnected(true)
+    advanceTimers()
+    await wait(() => getByText(insertCardScreenText))
+  })
+
+  it('Displays error screen if Printer connection is lost', async () => {
+    const hardware = new MemoryHardware()
+    setElectionInStorage(storage)
+    setStateInStorage(storage, {
+      appMode: VxPrintOnly,
+    })
+    const { getByText } = render(
+      <App card={card} hardware={hardware} storage={storage} />
+    )
+
+    // Start on VxPrint Insert Card screen
+    const vxPrintInsertCardScreenText =
+      'Insert Card to print your official ballot.'
+    getByText(vxPrintInsertCardScreenText)
+
+    // Disconnect Printer
+    hardware.setPrinterConnected(false)
+    advanceTimers()
+    await wait(() => getByText('No Printer Detected'))
+
+    // Reconnect Printer
+    hardware.setPrinterConnected(true)
+    advanceTimers()
+    await wait(() => getByText(vxPrintInsertCardScreenText))
+  })
+
+  it('Displays "discharging battery" warning message and "discharging battery + low battery" error screen', async () => {
+    const hardware = new MemoryHardware()
+    setElectionInStorage(storage)
+    setStateInStorage(storage)
+    const { getByText, queryByText } = render(
+      <App card={card} hardware={hardware} storage={storage} />
+    )
+    const getByTextWithMarkup = withMarkup(getByText)
+
+    // Start on VxMark Insert Card screen
+    getByText(insertCardScreenText)
+
+    // Remove charger and reduce battery level slightly
+    hardware.setBatteryDischarging(true)
+    hardware.setBatteryLevel(0.6)
+    advanceTimers()
+    await wait(() => getByText(noPowerDetectedWarningText))
+    getByText(insertCardScreenText)
+
+    // Battery level drains below GLOBALS.LOW_BATTERY_THRESHOLD
+    hardware.setBatteryLevel(0.24)
+    advanceTimers()
+    await wait(() => getByTextWithMarkup(lowBatteryErrorScreenText))
+
+    // Attach charger and back on Insert Card screen
+    hardware.setBatteryDischarging(false)
+    advanceTimers()
+    await wait(() => !queryByText(noPowerDetectedWarningText))
+    getByText(insertCardScreenText)
+  })
+
+  it('Cause hardware status polling to catch', async () => {
+    const hardware = new MemoryHardware()
+    setElectionInStorage(storage)
+    setStateInStorage(storage)
+    const { getByText } = render(
+      <App card={card} hardware={hardware} storage={storage} />
+    )
+
+    // Mock failed card reader response
+    const readReaderStatusMock = jest
+      .spyOn(hardware, 'readCardReaderStatus')
+      .mockRejectedValue(new Error('NOPE'))
+
+    // Ensure polling interval time is passed
+    advanceTimers()
+
+    // Wait for component to render
+    await wait(() => getByText(insertCardScreenText))
+
+    // Expect that hardware status was called once
+    expect(readReaderStatusMock).toHaveBeenCalledTimes(1)
+
+    // Ensure hardware status interval time is passed again
+    advanceTimers()
+
+    // Expect that hardware status has not been called again
+    expect(readReaderStatusMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Single Seat Contest 1`] = `
-.c0 {
-  height: 100%;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 .c17 {
   border: none;
   border-radius: 0.25rem;
@@ -548,6 +540,14 @@ exports[`Single Seat Contest 1`] = `
   height: 1.375rem;
   vertical-align: text-bottom;
   content: '';
+}
+
+.c0 {
+  height: 100%;
+}
+
+.c0:focus {
+  outline: none;
 }
 
 @media (min-width:480px) {

--- a/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Single Seat Contest 1`] = `
-.c0 {
-  height: 100%;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 .c17 {
   border: none;
   border-radius: 0.25rem;
@@ -548,6 +540,14 @@ exports[`Single Seat Contest 1`] = `
   height: 1.375rem;
   vertical-align: text-bottom;
   content: '';
+}
+
+.c0 {
+  height: 100%;
+}
+
+.c0:focus {
+  outline: none;
 }
 
 @media (min-width:480px) {

--- a/src/__snapshots__/AppContestWriteIn.test.tsx.snap
+++ b/src/__snapshots__/AppContestWriteIn.test.tsx.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Single Seat Contest with Write In 1`] = `
-.c0 {
-  height: 100%;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 .c17 {
   border: none;
   border-radius: 0.25rem;
@@ -502,6 +494,14 @@ exports[`Single Seat Contest with Write In 1`] = `
   height: 1rem;
   vertical-align: text-bottom;
   content: '';
+}
+
+.c0 {
+  height: 100%;
+}
+
+.c0:focus {
+  outline: none;
 }
 
 @media (min-width:480px) {

--- a/src/config/globals.ts
+++ b/src/config/globals.ts
@@ -14,3 +14,4 @@ export enum YES_NO_VOTES {
   yes = 'Yes',
 }
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40
+export const LOW_BATTERY_THRESHOLD = 0.25

--- a/src/lib/gamepad.test.tsx
+++ b/src/lib/gamepad.test.tsx
@@ -18,6 +18,7 @@ import { getActiveElement, handleGamepadButtonDown } from './gamepad'
 import { MemoryStorage } from '../utils/Storage'
 import { AppStorage } from '../AppRoot'
 import { MemoryCard } from '../utils/Card'
+import { MemoryHardware } from '../utils/Hardware'
 
 beforeEach(() => {
   window.location.href = '/'
@@ -26,11 +27,14 @@ beforeEach(() => {
 it('gamepad controls work', async () => {
   jest.useFakeTimers()
 
-  const storage = new MemoryStorage<AppStorage>()
   const card = new MemoryCard()
+  const hardware = new MemoryHardware()
+  const storage = new MemoryStorage<AppStorage>()
   setElectionInStorage(storage)
   setStateInStorage(storage)
-  const { getByText } = render(<App storage={storage} card={card} />)
+  const { getByText } = render(
+    <App card={card} hardware={hardware} storage={storage} />
+  )
 
   card.insertCard(getNewVoterCard())
   advanceTimers()

--- a/src/pages/InsertCardScreen.tsx
+++ b/src/pages/InsertCardScreen.tsx
@@ -7,6 +7,7 @@ import Prose from '../components/Prose'
 import Screen from '../components/Screen'
 import Sidebar from '../components/Sidebar'
 import TestMode from '../components/TestMode'
+import Text from '../components/Text'
 import ElectionInfo from '../components/ElectionInfo'
 
 const InsertCardImage = styled.img`
@@ -17,15 +18,19 @@ const InsertCardImage = styled.img`
 interface Props {
   appPrecinctId: string
   election: Election
+  showNoChargerAttachedWarning: boolean
   isLiveMode: boolean
   isPollsOpen: boolean
+  showNoAccessibleControllerWarning: boolean
 }
 
 const ActivationScreen = ({
   appPrecinctId,
   election,
+  showNoChargerAttachedWarning,
   isLiveMode,
   isPollsOpen,
+  showNoAccessibleControllerWarning,
 }: Props) => {
   return (
     <Screen flexDirection="row-reverse" white>
@@ -36,6 +41,12 @@ const ActivationScreen = ({
         <MainChild center>
           <Prose textCenter>
             <TestMode isLiveMode={isLiveMode} />
+            {showNoChargerAttachedWarning && (
+              <Text warning small>
+                <strong>No Power Detected.</strong> Please ask a poll worker to
+                plug in the power cord for this machine.
+              </Text>
+            )}
             <p>
               <InsertCardImage
                 aria-hidden
@@ -53,6 +64,11 @@ const ActivationScreen = ({
                 <h1>Polls Closed</h1>
                 <p>Insert Poll Worker card to open.</p>
               </React.Fragment>
+            )}
+            {showNoAccessibleControllerWarning && (
+              <Text muted small>
+                Voting with an accessible controller is not currently available.
+              </Text>
             )}
           </Prose>
         </MainChild>

--- a/src/pages/SetupCardReaderPage.tsx
+++ b/src/pages/SetupCardReaderPage.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react'
+import Prose from '../components/Prose'
+import Main, { MainChild } from '../components/Main'
+import Screen from '../components/Screen'
+import { PartialUserSettings } from '../config/types'
+import { DEFAULT_FONT_SIZE, LARGE_DISPLAY_FONT_SIZE } from '../config/globals'
+
+interface Props {
+  setUserSettings: (partial: PartialUserSettings) => void
+}
+
+const ExpiredCardScreen = ({ setUserSettings }: Props) => {
+  useEffect(() => {
+    setUserSettings({ textSize: LARGE_DISPLAY_FONT_SIZE })
+    return () => {
+      setUserSettings({ textSize: DEFAULT_FONT_SIZE })
+    }
+  }, [setUserSettings])
+
+  return (
+    <Screen white>
+      <Main>
+        <MainChild center>
+          <Prose textCenter>
+            <h1>Card Reader Not Detected</h1>
+            <p>Please ask a poll worker to connect card reader.</p>
+          </Prose>
+        </MainChild>
+      </Main>
+    </Screen>
+  )
+}
+
+export default ExpiredCardScreen

--- a/src/pages/SetupPowerPage.tsx
+++ b/src/pages/SetupPowerPage.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react'
+import Prose from '../components/Prose'
+import Main, { MainChild } from '../components/Main'
+import Screen from '../components/Screen'
+import { NoWrap } from '../components/Text'
+import { PartialUserSettings } from '../config/types'
+import { DEFAULT_FONT_SIZE, LARGE_DISPLAY_FONT_SIZE } from '../config/globals'
+
+interface Props {
+  setUserSettings: (partial: PartialUserSettings) => void
+}
+
+const SetupPowerPage = ({ setUserSettings }: Props) => {
+  useEffect(() => {
+    setUserSettings({ textSize: LARGE_DISPLAY_FONT_SIZE })
+    return () => {
+      setUserSettings({ textSize: DEFAULT_FONT_SIZE })
+    }
+  }, [setUserSettings])
+
+  return (
+    <Screen white>
+      <Main padded>
+        <MainChild center>
+          <Prose textCenter>
+            <h1>
+              No Power Detected <NoWrap>and Battery is Low</NoWrap>
+            </h1>
+            <p>
+              Please ask a poll worker to plug-in the power cord for this
+              machine.
+            </p>
+          </Prose>
+        </MainChild>
+      </Main>
+    </Screen>
+  )
+}
+
+export default SetupPowerPage

--- a/src/pages/SetupPrinterPage.tsx
+++ b/src/pages/SetupPrinterPage.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react'
+import Prose from '../components/Prose'
+import Main, { MainChild } from '../components/Main'
+import Screen from '../components/Screen'
+import { PartialUserSettings } from '../config/types'
+import { DEFAULT_FONT_SIZE, LARGE_DISPLAY_FONT_SIZE } from '../config/globals'
+
+interface Props {
+  setUserSettings: (partial: PartialUserSettings) => void
+}
+
+const SetupPrinterPage = ({ setUserSettings }: Props) => {
+  useEffect(() => {
+    setUserSettings({ textSize: LARGE_DISPLAY_FONT_SIZE })
+    return () => {
+      setUserSettings({ textSize: DEFAULT_FONT_SIZE })
+    }
+  }, [setUserSettings])
+
+  return (
+    <Screen white>
+      <Main padded>
+        <MainChild center>
+          <Prose textCenter>
+            <h1>No Printer Detected</h1>
+            <p>Please ask a poll worker to connect printer.</p>
+          </Prose>
+        </MainChild>
+      </Main>
+    </Screen>
+  )
+}
+
+export default SetupPrinterPage

--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -1,0 +1,15 @@
+import fakeKiosk from '../../test/helpers/fakeKiosk'
+import { getHardware } from './Hardware'
+
+describe('KioskHardware', () => {
+  it('reads battery status from kiosk', async () => {
+    try {
+      window.kiosk = fakeKiosk()
+      const hardware = getHardware()
+      await hardware.readBatteryStatus()
+      expect(window.kiosk.getBatteryInfo).toHaveBeenCalledTimes(1)
+    } finally {
+      window.kiosk = undefined
+    }
+  })
+})

--- a/src/utils/Hardware.ts
+++ b/src/utils/Hardware.ts
@@ -1,0 +1,153 @@
+// eslint-disable-next-line import/no-unresolved
+import { Kiosk, BatteryInfo } from 'kiosk-browser'
+
+interface AccessibleControllerStatus {
+  connected: boolean
+}
+interface CardReaderStatus {
+  connected: boolean
+}
+interface PrinterStatus {
+  connected: boolean
+}
+
+/**
+ * Defines the API for accessing hardware status.
+ */
+export interface Hardware {
+  /**
+   * Reads Accessible Controller status
+   */
+  readAccesssibleControllerStatus(): Promise<AccessibleControllerStatus>
+
+  /**
+   * Reads Battery status
+   */
+  readBatteryStatus(): Promise<BatteryInfo>
+
+  /**
+   * Reads Card Reader status
+   */
+  readCardReaderStatus(): Promise<CardReaderStatus>
+
+  /**
+   * Reads Printer status
+   */
+  readPrinterStatus(): Promise<PrinterStatus>
+}
+
+/**
+ * Implements the `Hardware` API with an in-memory implementation.
+ */
+export class MemoryHardware implements Hardware {
+  private accessibleControllerStatus: AccessibleControllerStatus = {
+    connected: true,
+  }
+  private batteryStatus: BatteryInfo = {
+    discharging: false,
+    level: 0.8,
+  }
+  private cardReaderStatus: CardReaderStatus = {
+    connected: true,
+  }
+  private printerStatus: PrinterStatus = {
+    connected: true,
+  }
+
+  /**
+   * Reads Accessible Controller status
+   */
+  public async readAccesssibleControllerStatus(): Promise<
+    AccessibleControllerStatus
+  > {
+    return this.accessibleControllerStatus
+  }
+
+  /**
+   * Sets Accessible Controller connected
+   */
+  public async setAccesssibleControllerConnected(
+    connected: boolean
+  ): Promise<void> {
+    this.accessibleControllerStatus = { connected }
+  }
+
+  /**
+   * Reads Battery status
+   */
+  public async readBatteryStatus(): Promise<BatteryInfo> {
+    return this.batteryStatus
+  }
+
+  /**
+   * Sets Battery discharging
+   */
+  public async setBatteryDischarging(discharging: boolean): Promise<void> {
+    this.batteryStatus = {
+      ...this.batteryStatus,
+      discharging,
+    }
+  }
+
+  /**
+   * Sets Battery level. Number between 0–1.
+   */
+  public async setBatteryLevel(level: number): Promise<void> {
+    this.batteryStatus = {
+      ...this.batteryStatus,
+      level,
+    }
+  }
+
+  /**
+   * Reads Card Reader status
+   */
+  public async readCardReaderStatus(): Promise<CardReaderStatus> {
+    return this.cardReaderStatus
+  }
+
+  /**
+   * Sets Card Reader connected
+   */
+  public async setCardReaderConnected(connected: boolean): Promise<void> {
+    this.cardReaderStatus = { connected }
+  }
+
+  /**
+   * Reads Printer status
+   */
+  public async readPrinterStatus(): Promise<PrinterStatus> {
+    return this.printerStatus
+  }
+
+  /**
+   * Sets Printer connected
+   */
+  public async setPrinterConnected(connected: boolean): Promise<void> {
+    this.printerStatus = { connected }
+  }
+}
+
+/**
+ * Implements the `Hardware` API by accessing it through the kiosk.
+ */
+export class KioskHardware extends MemoryHardware {
+  private kiosk: Kiosk
+  public constructor(kiosk: Kiosk) {
+    super()
+    this.kiosk = kiosk
+  }
+
+  /**
+   * Reads Battery status
+   */
+  public async readBatteryStatus(): Promise<BatteryInfo> {
+    return this.kiosk.getBatteryInfo()
+  }
+}
+
+/**
+ * Get Hardware based upon environment.
+ */
+export const getHardware = () =>
+  window.kiosk ? new KioskHardware(window.kiosk) : new MemoryHardware()


### PR DESCRIPTION
Fixes #1041 

This PR needs:
- [x] backend data to enable screens.
- [x] tests based upon mocked data.

# Error Screens

These screens will display for all users if the state is such.

## Low battery and no charger
![image](https://user-images.githubusercontent.com/28444/72029195-01541100-323a-11ea-97f0-d50f4caeec77.png)

## Card Reader not detected
![image](https://user-images.githubusercontent.com/28444/72029217-17fa6800-323a-11ea-8afb-2a0141932f07.png)

## No Printer Detected
![image](https://user-images.githubusercontent.com/28444/72045743-b521c480-326b-11ea-8864-e38db6d64802.png)

## Printer Error Detected
![image](https://user-images.githubusercontent.com/28444/72045817-df738200-326b-11ea-8a3a-2670a86e8a7d.png)

# Warnings on Insert Card Screen

These warnings are informational but non-blocking. They are visible to both Poll Workers and Voters.

Note: It is possible for both of these warnings to appear at the same time.

## No Power Warning
![image](https://user-images.githubusercontent.com/28444/72111144-ca8c0280-32ee-11ea-8aa0-882c637cfe00.png)

## No Accessible Controller Warning
![image](https://user-images.githubusercontent.com/28444/72111187-e2fc1d00-32ee-11ea-91d7-bccc016cc754.png)
