### PR TITLE
fix: prefer US English voices in speech synthesis

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import {
 } from './utils/ScreenReader'
 import { WebServiceCard } from './utils/Card'
 import { LocalStorage } from './utils/Storage'
+import { getUSEnglishVoice } from './utils/voices'
+import memoize from './utils/memoize'
 
 window.oncontextmenu = (e: MouseEvent): void => {
   e.preventDefault()
@@ -32,7 +34,7 @@ export interface Props {
 
 const App = ({
   tts = {
-    enabled: new SpeechSynthesisTextToSpeech(),
+    enabled: new SpeechSynthesisTextToSpeech(memoize(getUSEnglishVoice)),
     disabled: new NullTextToSpeech(),
   },
   card = new WebServiceCard(),

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -42,7 +42,7 @@ function makeSpeechSynthesisDouble(): typeof speechSynthesis {
     addEventListener: jest.fn(),
     cancel: jest.fn(),
     dispatchEvent: jest.fn(),
-    getVoices: jest.fn(),
+    getVoices: jest.fn().mockImplementation(() => []),
     onvoiceschanged: jest.fn(),
     pause: jest.fn(),
     paused: false,

--- a/src/utils/ScreenReader.test.ts
+++ b/src/utils/ScreenReader.test.ts
@@ -1,6 +1,7 @@
 import { AriaScreenReader, SpeechSynthesisTextToSpeech } from './ScreenReader'
 import { text, element as h } from '../../test/helpers/domBuilders'
 import fakeTTS from '../../test/helpers/fakeTTS'
+import fakeVoice from '../../test/helpers/fakeVoice'
 
 describe('AriaScreenReader', () => {
   it('requires a text-to-speech engine', () => {
@@ -332,5 +333,16 @@ describe('SpeechSynthesisTextToSpeech', () => {
     expect(speechSynthesis.cancel).not.toHaveBeenCalled()
     tts.stop()
     expect(speechSynthesis.cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a voice getter', () => {
+    const voice = fakeVoice({ name: 'Alex' })
+    const tts = new SpeechSynthesisTextToSpeech(() => voice)
+
+    tts.speak('hello')
+
+    expect(speechSynthesis.speak).toHaveBeenCalledWith(
+      expect.objectContaining({ voice })
+    )
   })
 })

--- a/src/utils/ScreenReader.ts
+++ b/src/utils/ScreenReader.ts
@@ -245,7 +245,17 @@ export class AriaScreenReader implements ScreenReader {
   }
 }
 
+export interface VoiceSelector {
+  (): SpeechSynthesisVoice | undefined
+}
+
 export class SpeechSynthesisTextToSpeech implements TextToSpeech {
+  private getVoice?: VoiceSelector
+
+  public constructor(getVoice?: VoiceSelector) {
+    this.getVoice = getVoice
+  }
+
   /**
    * Directly triggers speech of text. Resolves when speaking is done.
    */
@@ -255,7 +265,14 @@ export class SpeechSynthesisTextToSpeech implements TextToSpeech {
   ): Promise<void> {
     return new Promise(resolve => {
       const utterance = new SpeechSynthesisUtterance(text)
+      const { getVoice } = this
+      const voice = getVoice?.()
+
       utterance.onend = () => resolve()
+
+      if (voice) {
+        utterance.voice = voice
+      }
 
       if (now) {
         speechSynthesis.cancel()

--- a/src/utils/memoize.test.ts
+++ b/src/utils/memoize.test.ts
@@ -1,0 +1,41 @@
+import memoize from './memoize'
+
+it('calls the underlying function as long as it returns undefined', () => {
+  const fn = jest.fn()
+  const mfn = memoize(fn)
+
+  // `fn` hasn't been called yet
+  expect(fn).toHaveBeenCalledTimes(0)
+
+  // first value is discarded since it's undefined
+  expect(mfn()).toBeUndefined()
+  expect(fn).toHaveBeenCalledTimes(1)
+
+  // second value is discarded since it's undefined
+  expect(mfn()).toBeUndefined()
+  expect(fn).toHaveBeenCalledTimes(2)
+
+  // finally a value is cached
+  fn.mockReturnValueOnce('cached!')
+  expect(mfn()).toBe('cached!')
+})
+
+it('stops calling the underlying function once it returns a value', () => {
+  let i = 0
+  const fn = jest.fn().mockImplementation(() => i++)
+  const mfn = memoize(fn)
+
+  // `fn` hasn't been called yet
+  expect(fn).toHaveBeenCalledTimes(0)
+  expect(i).toBe(0)
+
+  // first value is computed and cached
+  expect(mfn()).toBe(0)
+  expect(fn).toHaveBeenCalledTimes(1)
+  expect(i).toBe(1)
+
+  // first value is returned from cache
+  expect(mfn()).toBe(0)
+  expect(fn).toHaveBeenCalledTimes(1)
+  expect(i).toBe(1)
+})

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -1,0 +1,17 @@
+/**
+ * Memoizes the result of a function call that is expected to always return the
+ * same non-undefined value. Note that this is not the same return value given
+ * the arguments, but the same return value _every time_ no matter the
+ * arguments. The underlying function will be called until it returns a
+ * non-undefined value.
+ */
+export default function memoize<R, F extends () => R>(fn: F): () => R {
+  let returnValue: R
+
+  return () => {
+    if (typeof returnValue === 'undefined') {
+      returnValue = fn()
+    }
+    return returnValue
+  }
+}

--- a/src/utils/voices.test.ts
+++ b/src/utils/voices.test.ts
@@ -1,0 +1,83 @@
+import { mockOf } from '../../test/testUtils'
+import fakeVoice from '../../test/helpers/fakeVoice'
+import { getUSEnglishVoice } from './voices'
+
+describe('getUSEnglishVoice', () => {
+  it('returns nothing given no voices', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([])
+
+    expect(getUSEnglishVoice()).toBeUndefined()
+  })
+
+  it('never returns non-local voices', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      fakeVoice({ localService: false, name: 'Google US English' }),
+    ])
+
+    expect(getUSEnglishVoice()).toBeUndefined()
+  })
+
+  it('prefers the specific CMU voice', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      // Preferred over default
+      fakeVoice({ default: true }),
+      // Preferred over US English
+      fakeVoice({ name: 'US English' }),
+      // Preferred over English
+      fakeVoice({ name: 'English' }),
+      // Preferred over lang matches
+      fakeVoice({ lang: 'en-US' }),
+      fakeVoice({
+        name: 'English_(America) espeak-ng',
+      }),
+    ])
+
+    expect(getUSEnglishVoice()?.name).toBe('English_(America) espeak-ng')
+  })
+
+  it('prefers US English to UK English', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      fakeVoice({ name: 'Google UK English' }),
+      fakeVoice({ name: 'Google US English' }),
+    ])
+
+    expect(getUSEnglishVoice()?.name).toBe('Google US English')
+  })
+
+  it('prefers en-US over en', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      fakeVoice({ lang: 'en' }),
+      fakeVoice({ lang: 'en-US' }),
+    ])
+
+    expect(getUSEnglishVoice()?.lang).toBe('en-US')
+  })
+
+  it('prefers en over en-GB', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      fakeVoice({ lang: 'en-GB' }),
+      fakeVoice({ lang: 'en' }),
+    ])
+
+    expect(getUSEnglishVoice()?.lang).toBe('en')
+  })
+
+  it('falls back to the default if there is one', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      fakeVoice({ lang: 'af', default: false }),
+      fakeVoice({ default: true }),
+      fakeVoice({ name: 'Google 普通话（中国大陆）', default: false }),
+    ])
+
+    expect(getUSEnglishVoice()?.default).toBe(true)
+  })
+
+  it('falls back to the first one if none match or are the default', () => {
+    mockOf(speechSynthesis.getVoices).mockReturnValue([
+      fakeVoice({ lang: 'af', default: false }),
+      fakeVoice({ name: 'Google 普通话（中国大陆）', default: false }),
+    ])
+
+    expect(getUSEnglishVoice()?.lang).toBe('af')
+  })
+})

--- a/src/utils/voices.ts
+++ b/src/utils/voices.ts
@@ -1,0 +1,27 @@
+import { VoiceSelector } from './ScreenReader'
+
+/**
+ * Get a voice suitable for use with `speechSynthesis` APIs to be spoken to US
+ * English speakers.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const getUSEnglishVoice: VoiceSelector = () => {
+  // Only use local voices.
+  const voices = speechSynthesis.getVoices().filter(voice => voice.localService)
+
+  // Find voices in ranked order.
+  return (
+    // Prefer the CMU voice present on VxMark.
+    voices.find(voice => voice.name === 'English_(America) espeak-ng') ??
+    voices.find(
+      voice =>
+        /\bEnglish\b/i.test(voice.name) && /\b(US|America)\b/i.test(voice.name)
+    ) ??
+    voices.find(voice => /\bEnglish\b/i.test(voice.name)) ??
+    voices.find(voice => voice.lang === 'en-US') ??
+    voices.find(voice => voice.lang === 'en') ??
+    voices.find(voice => voice.lang.startsWith('en-')) ??
+    voices.find(voice => voice.default) ??
+    voices[0]
+  )
+}

--- a/test/helpers/fakeVoice.ts
+++ b/test/helpers/fakeVoice.ts
@@ -1,0 +1,12 @@
+export default function fakeVoice(
+  props: Partial<SpeechSynthesisVoice> = {}
+): SpeechSynthesisVoice {
+  return {
+    default: false,
+    lang: '',
+    localService: true,
+    name: '',
+    voiceURI: props.name ?? '',
+    ...props,
+  }
+}


### PR DESCRIPTION
This ensures we don't end up with an unusual default, such as "Afrikaans espeak-ng".
