### PR TITLE
fix: ensure unique keyboard row `key` attribute

### DIFF
--- a/src/components/VirtualKeyboard.tsx
+++ b/src/components/VirtualKeyboard.tsx
@@ -110,7 +110,7 @@ const VirtualKeyboard = ({
   <Keyboard data-testid="virtual-keyboard">
     {keyMap.rows.map(row => {
       return (
-        <div key={`row-${row.join()}`}>
+        <div key={`row-${row.map(key => key.label).join()}`}>
           {row.map(({ label, ariaLabel }) => (
             <Button
               key={label}


### PR DESCRIPTION
Adding a level of nesting to the data structure didn't affect the `join` since it still runs and type checks, but it stopped doing the right thing. Namely, the keys looked like `row-[object Object],[object Object]…`. Now they again look like `row-Q,W,E…`.
