### PR TITLE
fix: use the correct voice

### DIFF
--- a/src/utils/ScreenReader.ts
+++ b/src/utils/ScreenReader.ts
@@ -254,6 +254,10 @@ export class SpeechSynthesisTextToSpeech implements TextToSpeech {
 
   public constructor(getVoice?: VoiceSelector) {
     this.getVoice = getVoice
+
+    // Prime the speech synthesis engine. This call will likely return an empty
+    // array, but future ones should work properly.
+    speechSynthesis.getVoices()
   }
 
   /**

--- a/src/utils/voices.test.ts
+++ b/src/utils/voices.test.ts
@@ -17,7 +17,10 @@ describe('getUSEnglishVoice', () => {
     expect(getUSEnglishVoice()).toBeUndefined()
   })
 
-  it('prefers the specific CMU voice', () => {
+  it.each([
+    'cmu_us_slt_arctic_hts festival',
+    'cmu_us_slt_arctic_clunits festival',
+  ])('prefers the CMU voice "%s"', name => {
     mockOf(speechSynthesis.getVoices).mockReturnValue([
       // Preferred over default
       fakeVoice({ default: true }),
@@ -27,12 +30,10 @@ describe('getUSEnglishVoice', () => {
       fakeVoice({ name: 'English' }),
       // Preferred over lang matches
       fakeVoice({ lang: 'en-US' }),
-      fakeVoice({
-        name: 'English_(America) espeak-ng',
-      }),
+      fakeVoice({ name }),
     ])
 
-    expect(getUSEnglishVoice()?.name).toBe('English_(America) espeak-ng')
+    expect(getUSEnglishVoice()?.name).toBe(name)
   })
 
   it('prefers US English to UK English', () => {

--- a/src/utils/voices.ts
+++ b/src/utils/voices.ts
@@ -11,8 +11,9 @@ export const getUSEnglishVoice: VoiceSelector = () => {
 
   // Find voices in ranked order.
   return (
-    // Prefer the CMU voice present on VxMark.
-    voices.find(voice => voice.name === 'English_(America) espeak-ng') ??
+    // Prefer the CMU voices present on VxMark.
+    voices.find(voice => voice.name === 'cmu_us_slt_arctic_hts festival') ??
+    voices.find(voice => voice.name === 'cmu_us_slt_arctic_clunits festival') ??
     voices.find(
       voice =>
         /\bEnglish\b/i.test(voice.name) && /\b(US|America)\b/i.test(voice.name)


### PR DESCRIPTION
This uses the voices installed from the CMU festvox database: http://festvox.org/cmu_arctic/dbs_slt.html

It also attempts to work around issues with loading voices by loading the voices once before we actually need them.
