### PR TITLE
feat: add `kiosk.getPrinterInfo`

### DIFF
--- a/src/types/kiosk-browser.d.ts
+++ b/src/types/kiosk-browser.d.ts
@@ -4,8 +4,20 @@ declare module 'kiosk-browser' {
     level: number // Number between 0–1
   }
 
+  export interface PrinterInfo {
+    // Docs: http://electronjs.org/docs/api/structures/printer-info
+    description: string
+    isDefault: boolean
+    name: string
+    status: number
+    // Added via kiosk-browser
+    connected: boolean
+    options?: { [key: string]: string }
+  }
+
   export interface Kiosk {
     print(): Promise<void>
+    getPrinterInfo(): Promise<PrinterInfo[]>
     getBatteryInfo(): Promise<BatteryInfo>
   }
 }

--- a/test/helpers/fakeKiosk.ts
+++ b/test/helpers/fakeKiosk.ts
@@ -1,15 +1,32 @@
 // Disable `import/no-unresolved` because this module only exists for TypeScript.
 // eslint-disable-next-line import/no-unresolved
-import { Kiosk } from 'kiosk-browser'
+import { Kiosk, BatteryInfo, PrinterInfo } from 'kiosk-browser'
 
 /**
  * Builds a `Kiosk` instance with mock methods.
  */
-export default function fakeKiosk(): jest.Mocked<Kiosk> {
+export default function fakeKiosk({
+  battery: { level = 1, discharging = false } = {},
+  printers,
+}: {
+  battery?: Partial<BatteryInfo>
+  printers?: Partial<PrinterInfo>[]
+} = {}): jest.Mocked<Kiosk> {
+  if (!printers) {
+    printers = [{}]
+  }
+
+  printers = printers.map(printer => ({
+    connected: true,
+    description: 'Fake Printer',
+    isDefault: true,
+    name: 'Fake Printer',
+    ...printer,
+  }))
+
   return {
     print: jest.fn().mockResolvedValue(undefined),
-    getBatteryInfo: jest
-      .fn()
-      .mockResolvedValue({ level: 1, discharging: false }),
+    getBatteryInfo: jest.fn().mockResolvedValue({ level, discharging }),
+    getPrinterInfo: jest.fn().mockResolvedValue(printers),
   }
 }


### PR DESCRIPTION
This API allows us to determine which printers are connected so we can show status about a missing printer. This commit adds types and updates `fakeKiosk` to enable easier mocking.
