### PR TITLE
feat: add accessible controller and printer connection status

### DIFF
--- a/src/types/kiosk-browser.d.ts
+++ b/src/types/kiosk-browser.d.ts
@@ -15,10 +15,47 @@ declare module 'kiosk-browser' {
     options?: { [key: string]: string }
   }
 
+  export enum ChangeType {
+    Add,
+    Remove,
+  }
+
+  export interface Device {
+    locationId: number
+    vendorId: number
+    productId: number
+    deviceName: string
+    manufacturer: string
+    serialNumber: string
+    deviceAddress: number
+  }
+
+  export type DeviceChangeListener = (
+    changeType: ChangeType,
+    device: Device
+  ) => void
+
+  export interface Listener<
+    A extends unknown[],
+    C extends Function = (...args: A) => void
+  > {
+    remove(): void
+  }
+
+  export interface Listeners<
+    A extends unknown[],
+    C extends Function = (...args: A) => void
+  > {
+    add(callback: C): Listener<A, C>
+    remove(callback: C): void
+  }
+
   export interface Kiosk {
     print(): Promise<void>
     getPrinterInfo(): Promise<PrinterInfo[]>
     getBatteryInfo(): Promise<BatteryInfo>
+    getDeviceList(): Promise<Device[]>
+    onDeviceChange: Listeners<[ChangeType, Device]>
   }
 }
 

--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -1,15 +1,82 @@
-import fakeKiosk from '../../test/helpers/fakeKiosk'
-import { getHardware } from './Hardware'
+import fakeKiosk, {
+  fakeDevice,
+  fakePrinterInfo,
+} from '../../test/helpers/fakeKiosk'
+import { getHardware, KioskHardware } from './Hardware'
 
 describe('KioskHardware', () => {
-  it('reads battery status from kiosk', async () => {
+  it('is used by getHardware when window.kiosk is set', () => {
     try {
       window.kiosk = fakeKiosk()
       const hardware = getHardware()
-      await hardware.readBatteryStatus()
-      expect(window.kiosk.getBatteryInfo).toHaveBeenCalledTimes(1)
+      expect(hardware).toBeInstanceOf(KioskHardware)
     } finally {
       window.kiosk = undefined
     }
+  })
+
+  it('is not used by getHardware when window.kiosk is not set', () => {
+    expect(window.kiosk).toBeUndefined()
+    const hardware = getHardware()
+    expect(hardware).not.toBeInstanceOf(KioskHardware)
+  })
+
+  it('reads battery status from kiosk', async () => {
+    const kiosk = fakeKiosk()
+    const hardware = new KioskHardware(kiosk)
+    await hardware.readBatteryStatus()
+    expect(kiosk.getBatteryInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('sees an accessible controller if a device with the right vendor id & product id is present', async () => {
+    const kiosk = fakeKiosk()
+    const hardware = new KioskHardware(kiosk)
+
+    kiosk.getDeviceList.mockResolvedValueOnce([
+      fakeDevice({
+        vendorId: 0x0d8c,
+        productId: 0x0170,
+      }),
+    ])
+
+    expect(await hardware.readAccesssibleControllerStatus()).toEqual({
+      connected: true,
+    })
+  })
+
+  it('does not see an accessible controller if no device with the right vendor id & product id is present', async () => {
+    const kiosk = fakeKiosk()
+    const hardware = new KioskHardware(kiosk)
+
+    kiosk.getDeviceList.mockResolvedValueOnce([
+      fakeDevice({ vendorId: 0x0001, productId: 0x0001 }),
+    ])
+
+    expect(await hardware.readAccesssibleControllerStatus()).toEqual({
+      connected: false,
+    })
+  })
+
+  it('reports printer status as connected if there are any connected printers', async () => {
+    const kiosk = fakeKiosk()
+    const hardware = new KioskHardware(kiosk)
+
+    kiosk.getPrinterInfo.mockResolvedValueOnce([
+      fakePrinterInfo({ connected: false }),
+      fakePrinterInfo({ connected: true }),
+    ])
+
+    expect(await hardware.readPrinterStatus()).toEqual({ connected: true })
+  })
+
+  it('reports printer status as not connected if there are no connected printers', async () => {
+    const kiosk = fakeKiosk()
+    const hardware = new KioskHardware(kiosk)
+
+    kiosk.getPrinterInfo.mockResolvedValueOnce([
+      fakePrinterInfo({ connected: false }),
+    ])
+
+    expect(await hardware.readPrinterStatus()).toEqual({ connected: false })
   })
 })

--- a/test/helpers/fakeKiosk.ts
+++ b/test/helpers/fakeKiosk.ts
@@ -1,6 +1,30 @@
 // Disable `import/no-unresolved` because this module only exists for TypeScript.
 // eslint-disable-next-line import/no-unresolved
-import { Kiosk, BatteryInfo, PrinterInfo } from 'kiosk-browser'
+import { Kiosk, BatteryInfo, PrinterInfo, Device } from 'kiosk-browser'
+
+export function fakeDevice(props: Partial<Device> = {}): Device {
+  return {
+    deviceName: 'fake device',
+    deviceAddress: 0,
+    locationId: 0,
+    manufacturer: 'Acme Inc.',
+    productId: 0,
+    serialNumber: '12345',
+    vendorId: 0,
+    ...props,
+  }
+}
+
+export function fakePrinterInfo(props: Partial<PrinterInfo> = {}): PrinterInfo {
+  return {
+    connected: false,
+    description: props.name ?? 'Fake Printer',
+    isDefault: false,
+    name: 'Fake Printer',
+    status: 3, // idle
+    ...props,
+  }
+}
 
 /**
  * Builds a `Kiosk` instance with mock methods.
@@ -16,17 +40,16 @@ export default function fakeKiosk({
     printers = [{}]
   }
 
-  printers = printers.map(printer => ({
-    connected: true,
-    description: 'Fake Printer',
-    isDefault: true,
-    name: 'Fake Printer',
-    ...printer,
-  }))
+  printers = printers.map(fakePrinterInfo)
 
   return {
     print: jest.fn().mockResolvedValue(undefined),
     getBatteryInfo: jest.fn().mockResolvedValue({ level, discharging }),
     getPrinterInfo: jest.fn().mockResolvedValue(printers),
+    getDeviceList: jest.fn().mockResolvedValue([]),
+    onDeviceChange: {
+      add: jest.fn(),
+      remove: jest.fn(),
+    },
   }
 }


### PR DESCRIPTION
This code is particular about the specific vendor/product combination for the accessible controller. It only checks that there is a configured and connected printer at all, without caring that it's the exact one we want. This may change in the future.