### PR TITLE
feat: enable speech by default from speech-loader entry point

### DIFF
--- a/public/speech-loader.html
+++ b/public/speech-loader.html
@@ -16,11 +16,13 @@
 
       if (timeout <= now) {
         console.log('timeout exceeded waiting for voices, continuing anyway')
-        setTimeout(goToApp, oneSecond)
+        setTimeout(() => goToApp('reader=off'), oneSecond)
         return true
       } else {
         const seconds = Math.floor((timeout - now) / oneSecond)
-        console.log(`timeout not yet reached, still waiting for voices for ${seconds}s`)
+        console.log(
+          `timeout not yet reached, still waiting for voices for ${seconds}s`
+        )
       }
     } else {
       const timeout = Date.now() + secondsToWaitForVoices * oneSecond
@@ -32,8 +34,8 @@
     return false
   }
 
-  function goToApp() {
-    location.href = '/'
+  function goToApp(query = undefined) {
+    location.href = query ? `/?${query}` : '/'
   }
 
   /**
@@ -66,7 +68,7 @@
       setTimeout(tryAgain, oneSecond / 2)
     } else {
       console.log(`second check succeeded! found ${voices.length} voice(s)`)
-      setTimeout(goToApp, oneSecond / 2)
+      setTimeout(() => goToApp('reader=on'), oneSecond / 2)
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useCallback } from 'react'
 import { BrowserRouter, Route } from 'react-router-dom'
 
 import 'normalize.css'
@@ -9,8 +9,6 @@ import {
   ScreenReader,
   AriaScreenReader,
   SpeechSynthesisTextToSpeech,
-  NullTextToSpeech,
-  TextToSpeech,
 } from './utils/ScreenReader'
 import { WebServiceCard } from './utils/Card'
 import { LocalStorage } from './utils/Storage'
@@ -30,51 +28,26 @@ export interface Props {
   card?: AppRootProps['card']
   storage?: AppRootProps['storage']
   printer?: AppRootProps['printer']
-  tts?: {
-    enabled: TextToSpeech
-    disabled: TextToSpeech
-  }
+  screenReader?: ScreenReader
 }
 
 const App = ({
-  tts = {
-    enabled: new SpeechSynthesisTextToSpeech(memoize(getUSEnglishVoice)),
-    disabled: new NullTextToSpeech(),
-  },
+  screenReader = new AriaScreenReader(
+    new SpeechSynthesisTextToSpeech(memoize(getUSEnglishVoice))
+  ),
   card = new WebServiceCard(),
   storage = new LocalStorage<AppStorage>(),
   printer = getPrinter(),
   hardware = getHardware(),
 }: Props) => {
-  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false)
-  const [screenReader, setScreenReader] = useState<ScreenReader>(
-    new AriaScreenReader(tts.disabled)
-  )
-
   /* istanbul ignore next - need to figure out how to test this */
   const onKeyPress = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key === 'r') {
-        if (screenReaderEnabled) {
-          screenReader.onScreenReaderDisabled()
-          setScreenReader(new AriaScreenReader(tts.disabled))
-          setScreenReaderEnabled(false)
-        } else {
-          const newScreenReader = new AriaScreenReader(tts.enabled)
-          setScreenReader(newScreenReader)
-          setScreenReaderEnabled(true)
-          newScreenReader.onScreenReaderEnabled()
-        }
+        screenReader.toggle()
       }
     },
-    [
-      screenReader,
-      setScreenReader,
-      screenReaderEnabled,
-      setScreenReaderEnabled,
-      tts.disabled,
-      tts.enabled,
-    ]
+    [screenReader]
   )
 
   /* istanbul ignore next - need to figure out how to test this */

--- a/src/components/FocusManager.test.tsx
+++ b/src/components/FocusManager.test.tsx
@@ -2,11 +2,16 @@ import React from 'react'
 import { render } from '../../test/testUtils'
 
 import FocusManager from './FocusManager'
-import { AriaScreenReader, NullTextToSpeech } from '../utils/ScreenReader'
+import {
+  AriaScreenReader,
+  SpeechSynthesisTextToSpeech,
+} from '../utils/ScreenReader'
 
 it('renders FocusManager', async () => {
   const { container } = render(
-    <FocusManager screenReader={new AriaScreenReader(new NullTextToSpeech())}>
+    <FocusManager
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
+    >
       foo
     </FocusManager>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,9 +5,34 @@ import App from './App'
 import SampleApp from './SampleApp'
 
 import * as serviceWorker from './serviceWorker'
+import {
+  AriaScreenReader,
+  SpeechSynthesisTextToSpeech,
+} from './utils/ScreenReader'
+import memoize from './utils/memoize'
+import { getUSEnglishVoice } from './utils/voices'
+
+const isSampleApp = window.location.hash === '#sample'
+// FIXME: `?reader=on` won't be here on reload since we're using the browser
+// history `pushState` API to manipulate the location. Perhaps disable that
+// since we don't really care about page URLs anyway?
+const readerEnabled =
+  new URLSearchParams(window.location.search).get('reader') === 'on'
+const tts = new SpeechSynthesisTextToSpeech(memoize(getUSEnglishVoice))
+const screenReader = new AriaScreenReader(tts)
+
+if (readerEnabled) {
+  tts.unmute()
+} else {
+  tts.mute()
+}
 
 ReactDOM.render(
-  window.location.hash === '#sample' ? <SampleApp /> : <App />,
+  isSampleApp ? (
+    <SampleApp screenReader={screenReader} />
+  ) : (
+    <App screenReader={screenReader} />
+  ),
   document.getElementById('root')!
 )
 

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -49,7 +49,9 @@ function makeSpeechSynthesisDouble(): typeof speechSynthesis {
     pending: false,
     removeEventListener: jest.fn(),
     resume: jest.fn(),
-    speak: jest.fn(),
+    speak: jest.fn(async utterance =>
+      utterance.onend?.(new SpeechSynthesisEvent())
+    ),
     speaking: false,
   }
 }

--- a/test/helpers/fakeTTS.ts
+++ b/test/helpers/fakeTTS.ts
@@ -4,8 +4,17 @@ import { TextToSpeech } from '../../src/utils/ScreenReader'
  * Builds a fake `TextToSpeech` instance with mock functions.
  */
 export default function fakeTTS(): jest.Mocked<TextToSpeech> {
+  let isMuted = false
+
   return {
-    speak: jest.fn(),
+    speak: jest.fn().mockResolvedValue(undefined),
     stop: jest.fn(),
+    mute: jest.fn(() => {
+      isMuted = true
+    }),
+    unmute: jest.fn(() => {
+      isMuted = false
+    }),
+    isMuted: jest.fn(() => isMuted),
   }
 }


### PR DESCRIPTION
When speech-loader.html is able to load voices properly, it will load index.html with a query string parameter telling it to enable the screen reader right away.

The API needed to change to support this. Instead of swapping out `AriaScreenReader` instances with different text-to-speech implementations (null or real), we add the ability to mute TTS instances. This actually maps pretty well to the current volume control in the speech synthesis API which we may want to use in the future anyway. So now we keep the screen reader instance and just enable/disable it.

In addition, a number of tests were not waiting properly for the async methods they were calling. The tests worked anyway, but this fixes it to make the more correct.
