### PR TITLE
fix: correct some issues with polling

### DIFF
--- a/src/APICardCatch.test.tsx
+++ b/src/APICardCatch.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { fireEvent, render, wait } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 
 import App from './App'
 
-import { advanceTimers } from '../test/helpers/smartcards'
+import { advanceTimersAndPromises } from '../test/helpers/smartcards'
 
 import {
   setElectionInStorage,
@@ -39,16 +39,16 @@ it('Cause "/card/read" API to catch', async () => {
   )
 
   // Ensure card polling interval time is passed
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Wait for component to render
-  await wait(() => fireEvent.click(getByText('Insert Card')))
+  fireEvent.click(getByText('Insert Card'))
 
   // Expect that card API was called once
   expect(readStatusMock).toHaveBeenCalledTimes(1)
 
   // Ensure card polling interval time is passed again
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Expect that card API has not been called again
   expect(readStatusMock).toHaveBeenCalledTimes(1)

--- a/src/AppEndToEnd.test.tsx
+++ b/src/AppEndToEnd.test.tsx
@@ -11,7 +11,7 @@ import withMarkup from '../test/helpers/withMarkup'
 
 import {
   adminCard,
-  advanceTimers,
+  advanceTimersAndPromises,
   getAlternateNewVoterCard,
   getNewVoterCard,
   getUsedVoterCard,
@@ -35,7 +35,6 @@ beforeEach(() => {
 })
 
 jest.useFakeTimers()
-jest.setTimeout(20000) // TODO: Added after hardware polling added. Why?
 
 it('VxMark+Print end-to-end flow', async () => {
   const card = new MemoryCard()
@@ -49,7 +48,7 @@ it('VxMark+Print end-to-end flow', async () => {
   const getByTextWithMarkup = withMarkup(getByText)
 
   card.removeCard()
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Default Unconfigured
   getByText('Device Not Configured')
@@ -58,23 +57,23 @@ it('VxMark+Print end-to-end flow', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => fireEvent.click(getByText('Load Election Definition')))
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Load Election Definition'))
 
-  advanceTimers()
-  await wait(() => getByText('Election definition is loaded.'))
+  await advanceTimersAndPromises()
+  getByText('Election definition is loaded.')
 
   // Remove card and expect not configured because precinct not selected
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Device Not Configured'))
+  await advanceTimersAndPromises()
+  getByText('Device Not Configured')
 
   // ---------------
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => getByLabelText('Precinct'))
+  await advanceTimersAndPromises()
+  getByLabelText('Precinct')
 
   // Select precinct
   getByText('State of Hamilton')
@@ -95,54 +94,53 @@ it('VxMark+Print end-to-end flow', async () => {
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Polls Closed'))
+  await advanceTimersAndPromises()
+  getByText('Polls Closed')
   getByText('Insert Poll Worker card to open.')
 
   // ---------------
 
   // Open Polls with Poll Worker Card
   card.insertCard(pollWorkerCard)
-  advanceTimers()
-  await wait(() =>
-    fireEvent.click(getByText('Open Polls for Center Springfield'))
-  )
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Open Polls for Center Springfield'))
   getByText('Open polls and print Polls Opened report?')
   fireEvent.click(within(getByTestId('modal')).getByText('Yes'))
-  await wait(() => getByText('Close Polls for Center Springfield'))
+  await advanceTimersAndPromises()
+  getByText('Close Polls for Center Springfield')
   expect(printer.print).toHaveBeenCalledTimes(1)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
+  await advanceTimersAndPromises()
   await wait(() => getByText('Insert voter card to load ballot.'))
 
   // ---------------
 
   // Voter partially votes, remove card, and is on insert card screen.
   card.insertCard(getNewVoterCard())
-  advanceTimers()
+  await advanceTimersAndPromises()
   await wait(() => getByText(/Center Springfield/))
   getByText(/ballot style 12/)
   getByTextWithMarkup('Your ballot has 20 contests.')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
+  await advanceTimersAndPromises()
   await wait(() => getByText('Insert voter card to load ballot.'))
 
   // ---------------
 
   // Alternate Precinct
   card.insertCard(getAlternateNewVoterCard())
-  advanceTimers()
-  await wait(() => getByText('Invalid Card'))
+  await advanceTimersAndPromises()
+  getByText('Invalid Card')
   getByText('Card is not configured for this precinct.')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert voter card to load ballot.'))
+  await advanceTimersAndPromises()
+  getByText('Insert voter card to load ballot.')
 
   // ---------------
 
@@ -150,8 +148,8 @@ it('VxMark+Print end-to-end flow', async () => {
 
   // Insert Voter card
   card.insertCard(getNewVoterCard())
-  advanceTimers()
-  await wait(() => getByText(/Center Springfield/))
+  await advanceTimersAndPromises()
+  getByText(/Center Springfield/)
   getByText(/ballot style 12/)
   getByTextWithMarkup('Your ballot has 20 contests.')
 
@@ -169,7 +167,7 @@ it('VxMark+Print end-to-end flow', async () => {
   for (let i = 0; i < voterContests.length; i++) {
     const title = voterContests[i].title
 
-    advanceTimers()
+    await advanceTimersAndPromises()
     getByText(title)
 
     // Vote for candidate contest
@@ -181,13 +179,13 @@ it('VxMark+Print end-to-end flow', async () => {
       // We also need to advance timers so the interval will run, see that time has passed,
       // and finally write to the card.
       advanceBy(1100)
-      advanceTimers()
+      await advanceTimersAndPromises()
       expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(1)
 
       // If we wait another second and advance timers, without any change made to the card,
       // we should not see another call to save the card data
       advanceBy(1100)
-      advanceTimers()
+      await advanceTimersAndPromises()
       expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(1)
     }
 
@@ -200,7 +198,7 @@ it('VxMark+Print end-to-end flow', async () => {
   }
 
   // Review Screen
-  advanceTimers()
+  await advanceTimersAndPromises()
   getByText('Review Votes')
   getByText(presidentContest.candidates[0].name)
   getByText(`Yes on ${measure102Contest.shortTitle}`)
@@ -211,7 +209,7 @@ it('VxMark+Print end-to-end flow', async () => {
       `${countyCommissionersContest.section}${countyCommissionersContest.title}`
     )
   )
-  advanceTimers()
+  await advanceTimersAndPromises()
   getByText(/Vote for 4/i)
 
   // Select first candidate
@@ -220,7 +218,7 @@ it('VxMark+Print end-to-end flow', async () => {
 
   // Back to Review screen
   fireEvent.click(getByText('Review'))
-  advanceTimers()
+  await advanceTimersAndPromises()
   getByText('Review Your Votes')
   getByText(countyCommissionersContest.candidates[0].name)
   getByText(countyCommissionersContest.candidates[1].name)
@@ -228,56 +226,54 @@ it('VxMark+Print end-to-end flow', async () => {
 
   // Print Screen
   fireEvent.click(getByTextWithMarkup('I’m Ready to Print My Ballot'))
-  advanceTimers()
+  await advanceTimersAndPromises()
   getByText('Printing Official Ballot')
 
   // After timeout, show Verify and Cast Instructions
-  await wait() // TODO: unsure why this `wait` is needed, but it is.
-  advanceTimers(printerMessageTimeoutSeconds)
-  await wait(() => getByText('You’re Almost Done…'))
+  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  getByText('You’re Almost Done…')
   expect(printer.print).toHaveBeenCalledTimes(2)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert voter card to load ballot.'))
+  await advanceTimersAndPromises()
+  getByText('Insert voter card to load ballot.')
 
   // Insert Voter card which has just printed to see "cast" instructions again.
   card.insertCard(getUsedVoterCard())
-  advanceTimers()
-  await wait(() => getByText('You’re Almost Done…'))
+  await advanceTimersAndPromises()
+  getByText('You’re Almost Done…')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert voter card to load ballot.'))
+  await advanceTimersAndPromises()
+  getByText('Insert voter card to load ballot.')
 
   // ---------------
 
   // Close Polls with Poll Worker Card
   card.insertCard(pollWorkerCard)
-  advanceTimers()
-  await wait(() =>
-    fireEvent.click(getByText('Close Polls for Center Springfield'))
-  )
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Close Polls for Center Springfield'))
   getByText('Close Polls and print Polls Closed report?')
   fireEvent.click(within(getByTestId('modal')).getByText('Yes'))
-  await wait(() => getByText('Open Polls for Center Springfield'))
+  await advanceTimersAndPromises()
+  getByText('Open Polls for Center Springfield')
   expect(printer.print).toHaveBeenCalledTimes(3)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Poll Worker card to open.'))
+  await advanceTimersAndPromises()
+  getByText('Insert Poll Worker card to open.')
 
   // ---------------
 
   // Unconfigure with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => getByText('Election definition is loaded.'))
+  await advanceTimersAndPromises()
+  getByText('Election definition is loaded.')
   fireEvent.click(getByText('Remove'))
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Default Unconfigured
   getByText('Device Not Configured')

--- a/src/AppMarkOnly.test.tsx
+++ b/src/AppMarkOnly.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, wait, within } from '@testing-library/react'
+import { fireEvent, render, within } from '@testing-library/react'
 import { electionSample } from '@votingworks/ballot-encoder'
 
 import App from './App'
@@ -8,7 +8,7 @@ import withMarkup from '../test/helpers/withMarkup'
 
 import {
   adminCard,
-  advanceTimers,
+  advanceTimersAndPromises,
   getExpiredVoterCard,
   getNewVoterCard,
   pollWorkerCard,
@@ -40,7 +40,7 @@ it('VxMarkOnly flow', async () => {
   const getByTextWithMarkup = withMarkup(getByText)
 
   card.removeCard()
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Default Unconfigured
   getByText('Device Not Configured')
@@ -49,23 +49,23 @@ it('VxMarkOnly flow', async () => {
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => fireEvent.click(getByText('Load Election Definition')))
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Load Election Definition'))
 
-  advanceTimers()
-  await wait(() => getByText('Election definition is loaded.'))
+  await advanceTimersAndPromises()
+  getByText('Election definition is loaded.')
 
   // Remove card and expect not configured because precinct not selected
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Device Not Configured'))
+  await advanceTimersAndPromises()
+  getByText('Device Not Configured')
 
   // ---------------
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => getByLabelText('Precinct'))
+  await advanceTimersAndPromises()
+  getByLabelText('Precinct')
 
   // select precinct
   getByText('State of Hamilton')
@@ -85,48 +85,46 @@ it('VxMarkOnly flow', async () => {
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Polls Closed'))
+  await advanceTimersAndPromises()
+  getByText('Polls Closed')
   getByText('Insert Poll Worker card to open.')
 
   // ---------------
 
   // Open Polls with Poll Worker Card
   card.insertCard(pollWorkerCard)
-  advanceTimers()
-  await wait(() =>
-    fireEvent.click(getByText('Open Polls for Center Springfield'))
-  )
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Open Polls for Center Springfield'))
   getByText('Close Polls for Center Springfield')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert voter card to load ballot.'))
+  await advanceTimersAndPromises()
+  getByText('Insert voter card to load ballot.')
 
   // ---------------
 
   // Insert Expired Voter Card
   card.insertCard(getExpiredVoterCard())
-  advanceTimers()
-  await wait(() => getByText('Expired Card'))
+  await advanceTimersAndPromises()
+  getByText('Expired Card')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // // ---------------
 
   // Insert Expired Voter Card With Votes
   card.insertCard(getExpiredVoterCard())
-  advanceTimers()
-  await wait(() => getByText('Expired Card'))
+  await advanceTimersAndPromises()
+  getByText('Expired Card')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
@@ -134,8 +132,8 @@ it('VxMarkOnly flow', async () => {
 
   // Insert Voter card
   card.insertCard(getNewVoterCard())
-  advanceTimers()
-  await wait(() => getByText(/Center Springfield/))
+  await advanceTimersAndPromises()
+  getByText(/Center Springfield/)
   getByText(/ballot style 12/)
   getByTextWithMarkup('Your ballot has 20 contests.')
   fireEvent.click(getByText('Start Voting'))
@@ -144,7 +142,7 @@ it('VxMarkOnly flow', async () => {
   for (let i = 0; i < voterContests.length; i++) {
     const title = voterContests[i].title
 
-    advanceTimers()
+    await advanceTimersAndPromises()
     getByText(title)
 
     // Vote for candidate contest
@@ -160,50 +158,48 @@ it('VxMarkOnly flow', async () => {
   }
 
   // Review Screen
-  advanceTimers()
+  await advanceTimersAndPromises()
   getByText('Review Your Votes')
   getByText(presidentContest.candidates[0].name)
   getByText(`Yes on ${measure102Contest.shortTitle}`)
 
   // Print Screen
   fireEvent.click(getByTextWithMarkup('I’m Ready to Print My Ballot'))
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Saving votes
   getByText('Saving your votes to the card')
-  advanceTimers(2.5) // redirect after 2.5 seconds
+  await advanceTimersAndPromises(2.5) // redirect after 2.5 seconds
 
   // Review and Cast Instructions
   getByText('Take your card to the Ballot Printer.')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert voter card to load ballot.'))
+  await advanceTimersAndPromises()
+  getByText('Insert voter card to load ballot.')
 
   // ---------------
 
   // Close Polls with Poll Worker Card
   card.insertCard(pollWorkerCard)
-  advanceTimers()
-  await wait(() =>
-    fireEvent.click(getByText('Close Polls for Center Springfield'))
-  )
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Close Polls for Center Springfield'))
   getByText('Open Polls for Center Springfield')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Poll Worker card to open.'))
+  await advanceTimersAndPromises()
+  getByText('Insert Poll Worker card to open.')
 
   // ---------------
 
   // Unconfigure with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => getByText('Election definition is loaded.'))
+  await advanceTimersAndPromises()
+  getByText('Election definition is loaded.')
   fireEvent.click(getByText('Remove'))
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Default Unconfigured
   getByText('Device Not Configured')

--- a/src/AppPrintOnly.test.tsx
+++ b/src/AppPrintOnly.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, wait, within } from '@testing-library/react'
+import { fireEvent, render, within } from '@testing-library/react'
 import {
   electionSample,
   encodeBallot,
@@ -10,7 +10,7 @@ import App from './App'
 
 import {
   adminCard,
-  advanceTimers,
+  advanceTimersAndPromises,
   getExpiredVoterCard,
   getNewVoterCard,
   getUsedVoterCard,
@@ -35,7 +35,6 @@ beforeEach(() => {
 })
 
 jest.useFakeTimers()
-jest.setTimeout(20000) // TODO: Added after hardware polling added. Why?
 
 it('VxPrintOnly flow', async () => {
   const card = new MemoryCard()
@@ -49,7 +48,7 @@ it('VxPrintOnly flow', async () => {
   const getAllByTextWithMarkup = withMarkup(getAllByText)
 
   card.removeCard()
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Default Unconfigured
   getByText('Device Not Configured')
@@ -58,11 +57,11 @@ it('VxPrintOnly flow', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => fireEvent.click(getByText('Load Election Definition')))
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Load Election Definition'))
 
-  advanceTimers()
-  await wait(() => getByText('Election definition is loaded.'))
+  await advanceTimersAndPromises()
+  getByText('Election definition is loaded.')
 
   fireEvent.click(getByText('VxPrint Only'))
   expect((getByText('VxPrint Only') as HTMLButtonElement).disabled).toBeTruthy()
@@ -74,15 +73,15 @@ it('VxPrintOnly flow', async () => {
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Device Not Configured'))
+  await advanceTimersAndPromises()
+  getByText('Device Not Configured')
 
   // ---------------
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => getByLabelText('Precinct'))
+  await advanceTimersAndPromises()
+  getByLabelText('Precinct')
 
   // Select precinct
   getByText('State of Hamilton')
@@ -95,63 +94,62 @@ it('VxPrintOnly flow', async () => {
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Polls Closed'))
+  await advanceTimersAndPromises()
+  getByText('Polls Closed')
   getByText('Insert Poll Worker card to open.')
 
   // ---------------
 
   // Open Polls with Poll Worker Card
   card.insertCard(pollWorkerCard)
-  advanceTimers()
-  await wait(() =>
-    fireEvent.click(getByText('Open Polls for Center Springfield'))
-  )
+  await advanceTimersAndPromises()
+  fireEvent.click(getByText('Open Polls for Center Springfield'))
   getByText('Open polls and print Polls Opened report?')
   fireEvent.click(within(getByTestId('modal')).getByText('Yes'))
-  await wait(() => getByText('Close Polls for Center Springfield'))
+  await advanceTimersAndPromises()
+  getByText('Close Polls for Center Springfield')
   expect(printer.print).toHaveBeenCalledTimes(1)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
   // Insert Expired Voter Card
   card.insertCard(getExpiredVoterCard())
-  advanceTimers()
-  await wait(() => getByText('Expired Card'))
+  await advanceTimersAndPromises()
+  getByText('Expired Card')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
   // Insert Used Voter Card
   card.insertCard(getUsedVoterCard())
-  advanceTimers()
-  await wait(() => getByText('Used Card'))
+  await advanceTimersAndPromises()
+  getByText('Used Card')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
   // Insert Voter Card with No Votes
   card.insertCard(getNewVoterCard())
-  advanceTimers()
-  await wait(() => getByText('Empty Card'))
+  await advanceTimersAndPromises()
+  getByText('Empty Card')
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
@@ -170,19 +168,18 @@ it('VxPrintOnly flow', async () => {
   )
 
   // Show Printing Ballot screen
-  advanceTimers()
-  await wait() // TODO: unsure why this `wait` is needed, but it is.
+  await advanceTimersAndPromises()
   getByText('Printing your official ballot')
 
   // After timeout, show Verify and Cast Instructions
-  advanceTimers(printerMessageTimeoutSeconds)
-  await wait(() => getByText('Verify and Cast Your Printed Ballot'))
+  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  getByText('Verify and Cast Your Printed Ballot')
   expect(printer.print).toHaveBeenCalledTimes(2)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
@@ -201,19 +198,18 @@ it('VxPrintOnly flow', async () => {
   )
 
   // Show Printing Ballot screen
-  advanceTimers()
-  await wait() // TODO: unsure why this `wait` is needed, but it is.
+  await advanceTimersAndPromises()
   getByText('Printing your official ballot')
 
   // After timeout, show Verify and Cast Instructions
-  advanceTimers(printerMessageTimeoutSeconds)
-  await wait(() => getByText('Verify and Cast Your Printed Ballot'))
+  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  getByText('Verify and Cast Your Printed Ballot')
   expect(printer.print).toHaveBeenCalledTimes(3)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
@@ -232,26 +228,25 @@ it('VxPrintOnly flow', async () => {
   )
 
   // Show Printing Ballot screen
-  advanceTimers()
-  await wait() // TODO: unsure why this `wait` is needed, but it is.
+  await advanceTimersAndPromises()
   getByText('Printing your official ballot')
 
   // After timeout, show Verify and Cast Instructions
-  advanceTimers(printerMessageTimeoutSeconds)
-  await wait(() => getByText('Verify and Cast Your Printed Ballot'))
+  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  getByText('Verify and Cast Your Printed Ballot')
   expect(printer.print).toHaveBeenCalledTimes(4)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Card'))
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
 
   // ---------------
 
   // Pollworker Closes Polls
   card.insertCard(pollWorkerCard)
-  advanceTimers()
-  await wait(() => getByText('Close Polls for Center Springfield'))
+  await advanceTimersAndPromises()
+  getByText('Close Polls for Center Springfield')
 
   // Check for Report Details
   expect(getAllByTextWithMarkup('Ballots printed count: 3').length).toBe(2)
@@ -286,22 +281,23 @@ it('VxPrintOnly flow', async () => {
   fireEvent.click(getByText('Close Polls for Center Springfield'))
   getByText('Close Polls and print Polls Closed report?')
   fireEvent.click(within(getByTestId('modal')).getByText('Yes'))
-  await wait(() => getByText('Open Polls for Center Springfield'))
+  await advanceTimersAndPromises()
+  getByText('Open Polls for Center Springfield')
   expect(printer.print).toHaveBeenCalledTimes(5)
 
   // Remove card
   card.removeCard()
-  advanceTimers()
-  await wait(() => getByText('Insert Poll Worker card to open.'))
+  await advanceTimersAndPromises()
+  getByText('Insert Poll Worker card to open.')
 
   // ---------------
 
   // Unconfigure with Admin Card
   card.insertCard(adminCard, electionSample)
-  advanceTimers()
-  await wait(() => getByText('Election definition is loaded.'))
+  await advanceTimersAndPromises()
+  getByText('Election definition is loaded.')
   fireEvent.click(getByText('Remove'))
-  advanceTimers()
+  await advanceTimersAndPromises()
 
   // Default Unconfigured
   getByText('Device Not Configured')

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -356,7 +356,7 @@ class AppRoot extends React.Component<Props, State> {
   }
 
   public stopShortValueReadPolling = () => {
-    this.cardPoller && this.cardPoller.stop()
+    this.cardPoller?.stop()
     this.cardPoller = undefined
   }
 

--- a/src/utils/polling.test.ts
+++ b/src/utils/polling.test.ts
@@ -1,3 +1,4 @@
+import { wait } from '@testing-library/react'
 import { IntervalPoller } from './polling'
 
 describe('IntervalPoller', () => {
@@ -5,13 +6,16 @@ describe('IntervalPoller', () => {
     jest.useFakeTimers()
   })
 
-  it('polls at a specific interval', () => {
+  it('polls at a specific interval', async () => {
     const callback = jest.fn()
 
     IntervalPoller.start(10, callback)
 
     jest.advanceTimersByTime(10)
     expect(callback).toHaveBeenCalledTimes(1)
+
+    // Wait for promises to resolve in timeout.
+    await wait()
 
     jest.advanceTimersByTime(10)
     expect(callback).toHaveBeenCalledTimes(2)
@@ -49,5 +53,24 @@ describe('IntervalPoller', () => {
     poller.stop()
     jest.advanceTimersByTime(10)
     expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('can stop a poller that has already fired once', async () => {
+    const callback = jest.fn()
+    const poller = IntervalPoller.start(10, callback)
+
+    // Make sure the callback is called at least once.
+    jest.advanceTimersByTime(10)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Stop polling.
+    poller.stop()
+
+    // Give the async-aware callback handler time to resolve.
+    await wait()
+
+    // Give it time to fire again, if there's a bug.
+    jest.advanceTimersByTime(10)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/helpers/smartcards.ts
+++ b/test/helpers/smartcards.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react'
+import { act, wait } from '@testing-library/react'
 import {
   CandidateContest,
   CompletedBallot,
@@ -186,4 +186,9 @@ export const advanceTimers = (seconds = 0) => {
       seconds ? seconds * 1000 : GLOBALS.CARD_POLLING_INTERVAL
     )
   })
+}
+
+export const advanceTimersAndPromises = async (seconds = 0) => {
+  advanceTimers(seconds)
+  await wait()
 }


### PR DESCRIPTION
Firstly, `setInterval` was causing calls to the polling callback to stack on top of each other. WIth polling hardware, this meant hammering the CPU. Now it waits until the callback resolves when a promise is returned.

Second, I think this is what was causing issues with our tests timing out. I realized they were related because the end-to-end tests started failing when I fixed `IntervalPoller`. This is because they were not waiting for the poller to schedule the next callback in the `finally`, which was happening after a promise tick. So now wherever we had `advanceTimers` I made a new call to `await advanceTimersAndPromises` that optionally advances time and also awaits promises to ensure that anything already resolved had a chance to continue. These tests now run in a reasonable amount of time.
