### PR TITLE
tweaks to make e2e work against current build of the EG backend

### DIFF
--- a/src/components/PrintedBallot.tsx
+++ b/src/components/PrintedBallot.tsx
@@ -16,7 +16,6 @@ import {
 
 import * as GLOBALS from '../config/globals'
 
-import { randomBase64 } from '../utils/random'
 import { findPartyById } from '../utils/find'
 import {
   getBallotStyle,
@@ -190,6 +189,7 @@ interface Props {
   isLiveMode: boolean
   precinctId: string
   votes: VotesDict
+  ballotId: string
 }
 
 const PrintBallot = ({
@@ -198,8 +198,8 @@ const PrintBallot = ({
   isLiveMode,
   precinctId,
   votes,
+  ballotId,
 }: Props) => {
-  const ballotId = randomBase64()
   const { county, date, seal, sealURL, state, parties, title } = election
   const partyPrimaryAdjective = getPartyPrimaryAdjectiveFromBallotStyle({
     ballotStyleId,

--- a/src/endToEnd.ts
+++ b/src/endToEnd.ts
@@ -1,20 +1,24 @@
-import { VotesDict } from '@votingworks/ballot-encoder'
+import { CompletedBallot } from '@votingworks/ballot-encoder'
 
 import { E2EAPI } from './config/types'
 import fetchJSON from './utils/fetchJSON'
 
-export default async function encryptBallot(
-  // eslint-disable-next-line
-  votes: VotesDict
-) {
+export default async function encryptBallot(ballot: CompletedBallot) {
   try {
     const { tracker } = await fetchJSON<E2EAPI>(
       '/electionguard/EncryptBallot',
       {
         method: 'post',
-        body: JSON.stringify(votes),
+        body: JSON.stringify({
+          ballot: ballot,
+          currentBallotCount: 0,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       }
     )
+
     return tracker
   } catch (error) {
     return ''

--- a/src/pages/TestBallotDeckScreen.tsx
+++ b/src/pages/TestBallotDeckScreen.tsx
@@ -16,6 +16,7 @@ import PrintedBallot from '../components/PrintedBallot'
 import Prose from '../components/Prose'
 import Sidebar from '../components/Sidebar'
 import Screen from '../components/Screen'
+import { randomBase64 } from '../utils/random'
 
 interface Ballot {
   ballotId?: string
@@ -207,6 +208,7 @@ const TestBallotDeckScreen = ({
           <PrintedBallot
             // eslint-disable-next-line react/no-array-index-key
             key={`ballot-${i}`}
+            ballotId={randomBase64()}
             ballotStyleId={ballot.ballotStyleId}
             election={election}
             isLiveMode={isLiveMode}

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -10,7 +10,10 @@ const proxy = require('http-proxy-middleware')
 
 module.exports = function(app) {
   app.use(proxy('/card', { target: 'http://localhost:3001/' }))
-  app.use(proxy('/electionguard', { target: 'http://localhost:5000/' }))
+  app.use(proxy('/electionguard', {
+    target: 'http://localhost:5000/',
+    pathRewrite: {'^/electionguard/EncryptBallot': '/election/EncryptBallot'}
+  }))
 
   app.get('/machine-id', (req, res) => {
     res.json({


### PR DESCRIPTION
The current EG backend expects calls to `/election/*` and requires the right content-type.

These changes are confirmed to work against the latest EG backend.

@beausmith this can be merged now or after your changes go in, I don't have any problems rebasing.