### PR TITLE
chore(package): remove unnecessary `git add` steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,13 @@
   "lint-staged": {
     "*.+(js|jsx|ts|tsx)": [
       "stylelint",
-      "eslint --quiet --fix",
-      "git add"
+      "eslint --quiet --fix"
     ],
     "*.css": [
-      "stylelint --config .stylelintrc-css.js --fix",
-      "git add"
+      "stylelint --config .stylelintrc-css.js --fix"
     ],
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
I got this warning from husky after an update:

```
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```
