### PR TITLE
test: ensure calls to /card/reader don't leak

### DIFF
--- a/src/AppData.test.tsx
+++ b/src/AppData.test.tsx
@@ -13,6 +13,7 @@ import {
 import { advanceTimers } from '../test/helpers/smartcards'
 import { MemoryStorage } from './utils/Storage'
 import fakeMachineId from '../test/helpers/fakeMachineId'
+import { MemoryHardware } from './utils/Hardware'
 
 jest.useFakeTimers()
 
@@ -22,7 +23,9 @@ beforeEach(() => {
 
 describe('loads election', () => {
   it('Machine is not configured by default', () => {
-    const { getByText } = render(<App machineId={fakeMachineId()} />)
+    const { getByText } = render(
+      <App machineId={fakeMachineId()} hardware={new MemoryHardware()} />
+    )
     getByText('Device Not Configured')
   })
 
@@ -32,7 +35,11 @@ describe('loads election', () => {
     setElectionInStorage(storage)
     setStateInStorage(storage)
     const { getByText } = render(
-      <App storage={storage} machineId={machineId} />
+      <App
+        storage={storage}
+        machineId={machineId}
+        hardware={new MemoryHardware()}
+      />
     )
     getByText(election.title)
     expect(storage.get(electionStorageKey)).toBeTruthy()

--- a/src/SampleApp.tsx
+++ b/src/SampleApp.tsx
@@ -6,6 +6,7 @@ import utcTimestamp from './utils/utcTimestamp'
 import { Storage, MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { Provider } from './config/types'
+import { MemoryHardware } from './utils/Hardware'
 
 const ballotStyleId = '12'
 const precinctId = '23'
@@ -60,9 +61,16 @@ const SampleApp = ({
   card = getSampleCard(),
   storage = getSampleStorage(),
   machineId = getSampleMachineId(),
+  hardware = new MemoryHardware(),
   ...rest
 }: Props) => (
-  <App card={card} storage={storage} machineId={machineId} {...rest} />
+  <App
+    card={card}
+    storage={storage}
+    machineId={machineId}
+    hardware={hardware}
+    {...rest}
+  />
 )
 
 export default SampleApp

--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -1,8 +1,9 @@
+import fetchMock from 'fetch-mock'
 import fakeKiosk, {
   fakeDevice,
   fakePrinterInfo,
 } from '../../test/helpers/fakeKiosk'
-import { getHardware, KioskHardware } from './Hardware'
+import { getHardware, KioskHardware, WebBrowserHardware } from './Hardware'
 
 describe('KioskHardware', () => {
   it('is used by getHardware when window.kiosk is set', () => {
@@ -78,5 +79,15 @@ describe('KioskHardware', () => {
     ])
 
     expect(await hardware.readPrinterStatus()).toEqual({ connected: false })
+  })
+})
+
+describe('WebBrowserHardware', () => {
+  it('gets card reader status by checking /card/reader', async () => {
+    const hardware = new WebBrowserHardware()
+
+    fetchMock.get('/card/reader', () => JSON.stringify({ connected: true }))
+
+    expect(await hardware.readCardReaderStatus()).toEqual({ connected: true })
   })
 })


### PR DESCRIPTION
We should not be using the "real" hardware classes in tests, so this uses `MemoryHardware` in the `AppData` tests. Also, adds a test to ensure `WebBrowserHardware#readCardReaderStatus` works as expected.
