### PR TITLE
feat: monitor card reader via USB device changes

### DIFF
--- a/src/AppData.test.tsx
+++ b/src/AppData.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, wait } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import App from './App'
 import SampleApp, { getSampleStorage } from './SampleApp'
@@ -10,10 +10,11 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election'
-import { advanceTimers } from '../test/helpers/smartcards'
+import { advanceTimersAndPromises } from '../test/helpers/smartcards'
 import { MemoryStorage } from './utils/Storage'
 import fakeMachineId from '../test/helpers/fakeMachineId'
 import { MemoryHardware } from './utils/Hardware'
+import { MemoryCard } from './utils/Card'
 
 jest.useFakeTimers()
 
@@ -22,25 +23,39 @@ beforeEach(() => {
 })
 
 describe('loads election', () => {
-  it('Machine is not configured by default', () => {
+  it('Machine is not configured by default', async () => {
     const { getByText } = render(
-      <App machineId={fakeMachineId()} hardware={MemoryHardware.standard} />
+      <App
+        machineId={fakeMachineId()}
+        card={new MemoryCard()}
+        hardware={MemoryHardware.standard}
+      />
     )
+
+    // Let the initial hardware detection run.
+    await advanceTimersAndPromises()
+
     getByText('Device Not Configured')
   })
 
-  it('from storage', () => {
+  it('from storage', async () => {
+    const card = new MemoryCard()
     const storage = new MemoryStorage<AppStorage>()
     const machineId = fakeMachineId()
     setElectionInStorage(storage)
     setStateInStorage(storage)
     const { getByText } = render(
       <App
+        card={card}
         storage={storage}
         machineId={machineId}
         hardware={MemoryHardware.standard}
       />
     )
+
+    // Let the initial hardware detection run.
+    await advanceTimersAndPromises()
+
     getByText(election.title)
     expect(storage.get(electionStorageKey)).toBeTruthy()
   })
@@ -48,12 +63,13 @@ describe('loads election', () => {
   it('sample app loads election and activates ballot', async () => {
     const storage = getSampleStorage()
     const { getAllByText, getByText } = render(<SampleApp storage={storage} />)
-    advanceTimers()
-    await wait(() => {
-      expect(getAllByText(election.title).length).toBeGreaterThan(1)
-      getByText(/Center Springfield/)
-      getByText(/ballot style 12/)
-    })
+
+    // Let the initial hardware detection run.
+    await advanceTimersAndPromises()
+
+    expect(getAllByText(election.title).length).toBeGreaterThan(1)
+    getByText(/Center Springfield/)
+    getByText(/ballot style 12/)
     expect(storage.get(electionStorageKey)).toBeTruthy()
     expect(storage.get(activationStorageKey)).toBeTruthy()
   })

--- a/src/AppTestMode.test.tsx
+++ b/src/AppTestMode.test.tsx
@@ -10,6 +10,9 @@ import {
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import fakeMachineId from '../test/helpers/fakeMachineId'
+import { advanceTimersAndPromises } from '../test/helpers/smartcards'
+import { MemoryHardware } from './utils/Hardware'
+import { MemoryCard } from './utils/Card'
 
 jest.useFakeTimers()
 
@@ -17,13 +20,25 @@ beforeEach(() => {
   window.location.href = '/'
 })
 
-it('Displays testing message if not live mode', () => {
+it('Displays testing message if not live mode', async () => {
+  const card = new MemoryCard()
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
   setElectionInStorage(storage)
   setStateInStorage(storage, {
     isLiveMode: false,
   })
-  const { getByText } = render(<App storage={storage} machineId={machineId} />)
+  const { getByText } = render(
+    <App
+      card={card}
+      storage={storage}
+      machineId={machineId}
+      hardware={MemoryHardware.standard}
+    />
+  )
+
+  // Let the initial hardware detection run.
+  await advanceTimersAndPromises()
+
   getByText('Testing Mode')
 })

--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -3,12 +3,7 @@ import fakeKiosk, {
   fakeDevice,
   fakePrinterInfo,
 } from '../../test/helpers/fakeKiosk'
-import {
-  getHardware,
-  KioskHardware,
-  WebBrowserHardware,
-  MemoryHardware,
-} from './Hardware'
+import { getHardware, KioskHardware, MemoryHardware } from './Hardware'
 
 describe('KioskHardware', () => {
   it('is used by getHardware when window.kiosk is set', () => {
@@ -66,20 +61,14 @@ describe('KioskHardware', () => {
   })
 })
 
-describe('WebBrowserHardware', () => {
-  it('gets card reader status by checking /card/reader', async () => {
-    const hardware = new WebBrowserHardware()
-
-    fetchMock.get('/card/reader', () => JSON.stringify({ connected: true }))
-
-    expect(await hardware.readCardReaderStatus()).toEqual({ connected: true })
-  })
-})
-
 describe('MemoryHardware', () => {
-  it('has a standard config with an accessible controller and printer', () => {
+  it('has a standard config with all the typical hardware', () => {
     const hardware = MemoryHardware.standard
-    expect(hardware.getDeviceList()).toHaveLength(2)
+    expect(hardware.getDeviceList()).toHaveLength(
+      1 + // accessible controller
+      1 + // printer
+        1 // card reader
+    )
   })
 
   it('has no connected devices by default', () => {

--- a/src/utils/IntervalPoller.test.ts
+++ b/src/utils/IntervalPoller.test.ts
@@ -1,5 +1,5 @@
 import { wait } from '@testing-library/react'
-import { IntervalPoller } from './polling'
+import IntervalPoller from './IntervalPoller'
 
 describe('IntervalPoller', () => {
   beforeEach(() => {

--- a/src/utils/IntervalPoller.ts
+++ b/src/utils/IntervalPoller.ts
@@ -1,8 +1,4 @@
-export interface Poller {
-  stop(): void
-}
-
-export class IntervalPoller implements Poller {
+export default class IntervalPoller {
   private interval: number
   private callback: () => Promise<void> | void
   private timeout?: ReturnType<typeof setTimeout>


### PR DESCRIPTION
This replaces the polling of `/card/reader` with a device add notification that checks for the specific card reader we use in production. The upside is that plugging or unpluging triggers updates immediately. The main downside is that this hardcodes a specific product rather than being generalized to any card reader that psycard supports. I think the trade-off is worth it, but I'm open to other opinions.