### PR TITLE
remove fake readCardReaderStatus implementation in KioskHardware

### DIFF
--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -57,10 +57,11 @@ describe('KioskHardware', () => {
     expect(await hardware.readPrinterStatus()).toEqual({ connected: false })
   })
 
-  it('has a stub implementation of readCardReaderStatus for now', async () => {
+  it('gets card reader status by checking /card/reader', async () => {
     const kiosk = fakeKiosk()
     const hardware = new KioskHardware(kiosk)
 
+    fetchMock.get('/card/reader', () => JSON.stringify({ connected: true }))
     expect(await hardware.readCardReaderStatus()).toEqual({ connected: true })
   })
 })

--- a/src/utils/Hardware.ts
+++ b/src/utils/Hardware.ts
@@ -272,14 +272,6 @@ export class KioskHardware extends WebBrowserHardware {
   }
 
   /**
-   * Reads Card Reader status
-   */
-  public async readCardReaderStatus(): Promise<CardReaderStatus> {
-    // TODO: replace this with a real implementation
-    return { connected: true }
-  }
-
-  /**
    * Determines whether there is a configured & connected printer.
    */
   public async readPrinterStatus(): Promise<PrinterStatus> {


### PR DESCRIPTION
I stupidly forgot to remove the method in `KioskHardware`, which means cardreader polling didn't happen in kiosk.

I know you've got an alternate implementation @eventualbuddha but since it does have some tradeoffs, I want to discuss it a bit, and in the meantime fix this stupid bug.