### PR TITLE
fix: correct the `SetupCardReaderPage` name

### DIFF
--- a/src/pages/SetupCardReaderPage.tsx
+++ b/src/pages/SetupCardReaderPage.tsx
@@ -9,7 +9,7 @@ interface Props {
   setUserSettings: (partial: PartialUserSettings) => void
 }
 
-const ExpiredCardScreen = ({ setUserSettings }: Props) => {
+const SetupCardReaderPage = ({ setUserSettings }: Props) => {
   useEffect(() => {
     setUserSettings({ textSize: LARGE_DISPLAY_FONT_SIZE })
     return () => {
@@ -31,4 +31,4 @@ const ExpiredCardScreen = ({ setUserSettings }: Props) => {
   )
 }
 
-export default ExpiredCardScreen
+export default SetupCardReaderPage


### PR DESCRIPTION
In debugging this is confusing because it would show `ExpiredCardScreen`. Also, `Screen` vs. `Page`?