### PR TITLE
fix: do not print multiple ballots

### DIFF
--- a/src/APICardCatch.test.tsx
+++ b/src/APICardCatch.test.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
 it('Cause "/card/read" API to catch', async () => {
   // Configure Machine
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
   setElectionInStorage(storage)

--- a/src/AppCardUnhappyPaths.test.tsx
+++ b/src/AppCardUnhappyPaths.test.tsx
@@ -33,7 +33,7 @@ it('Display App Card Unhappy Paths', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/AppContestMultiSeat.test.tsx
+++ b/src/AppContestMultiSeat.test.tsx
@@ -26,7 +26,7 @@ it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/AppContestSingleSeat.test.tsx
+++ b/src/AppContestSingleSeat.test.tsx
@@ -26,7 +26,7 @@ it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/AppContestWriteIn.test.tsx
+++ b/src/AppContestWriteIn.test.tsx
@@ -31,7 +31,7 @@ it('Single Seat Contest with Write In', async () => {
 
   const card = new MemoryCard()
   const printer = fakePrinter()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/AppContestYesNo.test.tsx
+++ b/src/AppContestYesNo.test.tsx
@@ -28,7 +28,7 @@ it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/AppData.test.tsx
+++ b/src/AppData.test.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
 describe('loads election', () => {
   it('Machine is not configured by default', () => {
     const { getByText } = render(
-      <App machineId={fakeMachineId()} hardware={new MemoryHardware()} />
+      <App machineId={fakeMachineId()} hardware={MemoryHardware.standard} />
     )
     getByText('Device Not Configured')
   })
@@ -38,7 +38,7 @@ describe('loads election', () => {
       <App
         storage={storage}
         machineId={machineId}
-        hardware={new MemoryHardware()}
+        hardware={MemoryHardware.standard}
       />
     )
     getByText(election.title)

--- a/src/AppEndToEnd.test.tsx
+++ b/src/AppEndToEnd.test.tsx
@@ -39,7 +39,7 @@ jest.useFakeTimers()
 
 it('VxMark+Print end-to-end flow', async () => {
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const printer = fakePrinter()
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()

--- a/src/AppMarkOnly.test.tsx
+++ b/src/AppMarkOnly.test.tsx
@@ -33,7 +33,7 @@ it('VxMarkOnly flow', async () => {
   jest.useFakeTimers()
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
   const { getByTestId, getByLabelText, getByText } = render(

--- a/src/AppMarkVoterCardInvalid.test.tsx
+++ b/src/AppMarkVoterCardInvalid.test.tsx
@@ -35,7 +35,7 @@ const idleScreenCopy =
 describe('Mark Card Void when voter is idle too long', () => {
   it('Display expired card if card marked as voided', async () => {
     const card = new MemoryCard()
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     const storage = new MemoryStorage<AppStorage>()
     const machineId = fakeMachineId()
 
@@ -96,7 +96,7 @@ describe('Mark Card Void when voter is idle too long', () => {
 
   it('Reset ballot when card write does not match card read.', async () => {
     const card = new MemoryCard()
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     const storage = new MemoryStorage<AppStorage>()
     const machineId = fakeMachineId()
 

--- a/src/AppPrintOnly.test.tsx
+++ b/src/AppPrintOnly.test.tsx
@@ -40,7 +40,7 @@ jest.useFakeTimers()
 it('VxPrintOnly flow', async () => {
   const card = new MemoryCard()
   const printer = fakePrinter()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
   const { getAllByText, getByLabelText, getByText, getByTestId } = render(

--- a/src/AppRefresh.test.tsx
+++ b/src/AppRefresh.test.tsx
@@ -28,7 +28,7 @@ it('Refresh window and expect to be on same contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -515,12 +515,10 @@ class AppRoot extends React.Component<Props, State> {
             const { hardware } = this.props
             const battery = await hardware.readBatteryStatus()
             const cardReader = await hardware.readCardReaderStatus()
-            const printer = await hardware.readPrinterStatus()
             this.setState({
               hasCardReaderAttached: cardReader.connected,
               hasChargerAttached: !battery.discharging,
               hasLowBattery: battery.level < GLOBALS.LOW_BATTERY_THRESHOLD,
-              hasPrinterAttached: printer.connected,
             })
           } catch (error) {
             this.stopHardwareStatusPolling() // Assume backend is unavailable.
@@ -535,12 +533,17 @@ class AppRoot extends React.Component<Props, State> {
 
       // watch for changes
       this.onDeviceChangeListener = hardware.onDeviceChange.add(
-        (changeType, device) => {
+        async (changeType, device) => {
           /* istanbul ignore else */
           if (isAccessibleController(device)) {
             this.setState({
               hasAccessibleControllerAttached:
                 changeType === 0 /* ChangeType.Add */,
+            })
+          } else {
+            const printer = await hardware.readPrinterStatus()
+            this.setState({
+              hasPrinterAttached: printer.connected,
             })
           }
         }

--- a/src/AppSetupErrors.test.tsx
+++ b/src/AppSetupErrors.test.tsx
@@ -34,7 +34,7 @@ const noPowerDetectedWarningText = 'No Power Detected.'
 
 describe('Displays setup warning messages and errors scrrens', () => {
   it('Displays warning if Accessible Controller connection is lost', async () => {
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     hardware.setAccesssibleControllerConnected(true)
 
     setElectionInStorage(storage)
@@ -69,7 +69,7 @@ describe('Displays setup warning messages and errors scrrens', () => {
   })
 
   it('Displays error screen if Card Reader connection is lost', async () => {
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     setElectionInStorage(storage)
     setStateInStorage(storage)
     const { getByText } = render(
@@ -96,7 +96,7 @@ describe('Displays setup warning messages and errors scrrens', () => {
   })
 
   it('Displays error screen if Printer connection is lost', async () => {
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     setElectionInStorage(storage)
     setStateInStorage(storage, {
       appMode: VxPrintOnly,
@@ -127,7 +127,7 @@ describe('Displays setup warning messages and errors scrrens', () => {
   })
 
   it('Displays "discharging battery" warning message and "discharging battery + low battery" error screen', async () => {
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     setElectionInStorage(storage)
     setStateInStorage(storage)
     const { getByText, queryByText } = render(
@@ -163,7 +163,7 @@ describe('Displays setup warning messages and errors scrrens', () => {
   })
 
   it('Cause hardware status polling to catch', async () => {
-    const hardware = new MemoryHardware()
+    const hardware = MemoryHardware.standard
     setElectionInStorage(storage)
     setStateInStorage(storage)
     const { getByText } = render(

--- a/src/SampleApp.tsx
+++ b/src/SampleApp.tsx
@@ -61,7 +61,7 @@ const SampleApp = ({
   card = getSampleCard(),
   storage = getSampleStorage(),
   machineId = getSampleMachineId(),
-  hardware = new MemoryHardware(),
+  hardware = MemoryHardware.standard,
   ...rest
 }: Props) => (
   <App

--- a/src/lib/gamepad.test.tsx
+++ b/src/lib/gamepad.test.tsx
@@ -29,7 +29,7 @@ it('gamepad controls work', async () => {
   jest.useFakeTimers()
 
   const card = new MemoryCard()
-  const hardware = new MemoryHardware()
+  const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineId = fakeMachineId()
 

--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -77,6 +77,11 @@ describe('WebBrowserHardware', () => {
 })
 
 describe('MemoryHardware', () => {
+  it('has a standard config with an accessible controller and printer', () => {
+    const hardware = MemoryHardware.standard
+    expect(hardware.getDeviceList()).toHaveLength(2)
+  })
+
   it('has no connected devices by default', () => {
     const hardware = new MemoryHardware()
     expect(hardware.getDeviceList()).toEqual([])


### PR DESCRIPTION
I believe the polling was the cause of the multiple ballots being printed, so this commit removes the polling. Instead, it only triggers a printer refresh when _any USB device (that isn't the accessible controller) is added or removed_. The reason polling caused so many ballots to be printed was that `kiosk-browser`'s `getPrinterInfo` API was calling out to `lpinfo -v`, which for some reason _does not include the Brother printer when it's actually printing_. This may or may not be true with other printers, but it does _not_ seem to be true with the Parallels "Print to Mac (PDF)" virtual printer. Yay testing with real hardware.

The changes to `MemoryHardware` to support this were to make printer status be like adding or removing a device, similar to the accessible controller. Also, this commit includes information about the Brother printer we use, but it's not tied to that printer and should work with anything that we've configured properly at the `lpadmin` layer.

Closes #1112 