### PR TITLE
Separate printing of ballot and tracking code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/styled-components": "^4.4.2",
     "@votingworks/ballot-encoder": "^1.2.0",
     "@votingworks/qrcode.react": "^1.0.0",
+    "@xstate/react": "^0.8.1",
     "abortcontroller-polyfill": "^1.4.0",
     "base64-js": "^1.3.1",
     "fetch-mock": "^8.3.2",
@@ -102,7 +103,8 @@
     "react-scripts": "3.3.0",
     "styled-components": "^4.4.1",
     "typescript": "^3.7.5",
-    "use-interval": "^1.2.1"
+    "use-interval": "^1.2.1",
+    "xstate": "^4.7.7"
   },
   "devDependencies": {
     "@codemod/parser": "^1.0.6",

--- a/src/AppEndToEnd.test.tsx
+++ b/src/AppEndToEnd.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, wait, within } from '@testing-library/react'
 import { advanceBy } from 'jest-date-mock'
 
 import { electionSample } from '@votingworks/ballot-encoder'
-import { printerMessageTimeoutSeconds } from './pages/PrintPage'
+import { printingMessageTimeoutSeconds } from './pages/PrintPage'
 
 import App from './App'
 
@@ -242,7 +242,7 @@ it('VxMark+Print end-to-end flow', async () => {
   getByText('Printing Official Ballot')
 
   // After timeout, show Verify and Cast Instructions
-  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  await advanceTimersAndPromises(printingMessageTimeoutSeconds)
   getByText('You’re Almost Done…')
   expect(printer.print).toHaveBeenCalledTimes(2)
 

--- a/src/AppPrintOnly.test.tsx
+++ b/src/AppPrintOnly.test.tsx
@@ -23,7 +23,7 @@ import {
 
 import withMarkup from '../test/helpers/withMarkup'
 
-import { printerMessageTimeoutSeconds } from './pages/PrintOnlyScreen'
+import { printingMessageTimeoutSeconds } from './pages/PrintOnlyScreen'
 import { MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
 import { MemoryCard } from './utils/Card'
@@ -180,7 +180,7 @@ it('VxPrintOnly flow', async () => {
   getByText('Printing your official ballot')
 
   // After timeout, show Verify and Cast Instructions
-  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  await advanceTimersAndPromises(printingMessageTimeoutSeconds)
   getByText('Verify and Cast Your Printed Ballot')
   expect(printer.print).toHaveBeenCalledTimes(2)
 
@@ -210,7 +210,7 @@ it('VxPrintOnly flow', async () => {
   getByText('Printing your official ballot')
 
   // After timeout, show Verify and Cast Instructions
-  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  await advanceTimersAndPromises(printingMessageTimeoutSeconds)
   getByText('Verify and Cast Your Printed Ballot')
   expect(printer.print).toHaveBeenCalledTimes(3)
 
@@ -240,7 +240,7 @@ it('VxPrintOnly flow', async () => {
   getByText('Printing your official ballot')
 
   // After timeout, show Verify and Cast Instructions
-  await advanceTimersAndPromises(printerMessageTimeoutSeconds)
+  await advanceTimersAndPromises(printingMessageTimeoutSeconds)
   getByText('Verify and Cast Your Printed Ballot')
   expect(printer.print).toHaveBeenCalledTimes(4)
 

--- a/src/components/PrintedBallot.tsx
+++ b/src/components/PrintedBallot.tsx
@@ -185,6 +185,7 @@ const YesNoContestResult = (props: {
   )
 
 interface Props {
+  ballotId?: string
   ballotStyleId: string
   election: Election
   isLiveMode: boolean
@@ -193,13 +194,13 @@ interface Props {
 }
 
 const PrintBallot = ({
+  ballotId = randomBase64(),
   ballotStyleId,
   election,
   isLiveMode,
   precinctId,
   votes,
 }: Props) => {
-  const ballotId = randomBase64()
   const { county, date, seal, sealURL, state, parties, title } = election
   const partyPrimaryAdjective = getPartyPrimaryAdjectiveFromBallotStyle({
     ballotStyleId,

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -14,11 +14,12 @@ import PrintedBallot from '../components/PrintedBallot'
 import Prose from '../components/Prose'
 import Screen from '../components/Screen'
 import isEmptyObject from '../utils/isEmptyObject'
+import { randomBase64 } from '../utils/random'
 
 import encryptBallot from '../endToEnd'
 import ElectionGuardBallotTrackingCode from '../components/ElectionGuardBallotTrackingCode'
 
-export const printerMessageTimeoutSeconds = 5
+export const printingMessageTimeoutSeconds = 4
 
 const Graphic = styled.img`
   margin: 0 auto -1rem;
@@ -51,7 +52,7 @@ const PrintPage = () => {
       updateTally()
       printerTimer.current = window.setTimeout(() => {
         resetBallot()
-      }, printerMessageTimeoutSeconds * 1000)
+      }, printingMessageTimeoutSeconds * 1000)
     }
   }, [markVoterCardPrinted, printer, resetBallot, updateTally])
 
@@ -90,6 +91,7 @@ const PrintPage = () => {
         </Main>
       </Screen>
       <PrintedBallot
+        ballotId={randomBase64()}
         ballotStyleId={ballotStyleId}
         election={election!}
         isLiveMode={isLiveMode}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,6 +2226,11 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@xstate/react@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-0.8.1.tgz#df200547cca24c909572b7aef1ddab8bca3a0603"
+  integrity sha512-8voZm4GX3x70lNQVvoGedoObPYapkQIbgMhE+xOQEsm8Ait4Zto6R01SZ6WJD4qvLl8JPV6uq96OcFRdEsVESg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -13751,6 +13756,11 @@ xmlchars@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-1.3.1.tgz#1dda035f833dbb4f86a0c28eaa6ca769214793cf"
   integrity sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==
+
+xstate@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.7.7.tgz#3533edec1f8d72f147009301f071dc35f1a5ac33"
+  integrity sha512-ctV7gShkDe+HOLP1MV78FRqWhNtmMJvtGjlgP10N6MeELVxGbvc54WrwfBv0e/xyjSaqveM48Pohut71naqVNA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
I took inspiration from @eventualbuddha's [comment](https://github.com/votingworks/bmd/pull/1116#discussion_r372519895) to implement with a state machine… but also took some shortcuts for time.

Also, pls note that I have purposely ignored the `PrintPage` used when device `appMode === "mark+print"`

![separate-printing-of-ballot-and-tracking-code](https://user-images.githubusercontent.com/28444/73522009-4cd28880-43bc-11ea-8ed5-51641ab1e4d6.gif)
