### PR TITLE
fix: ensure "Card Reader Not Detected" shows as expected

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -66,7 +66,11 @@ import utcTimestamp from './utils/utcTimestamp'
 import { Card } from './utils/Card'
 import IntervalPoller from './utils/IntervalPoller'
 import { Storage } from './utils/Storage'
-import { Hardware, isAccessibleController } from './utils/Hardware'
+import {
+  Hardware,
+  isAccessibleController,
+  isCardReader,
+} from './utils/Hardware'
 
 interface CardState {
   isClerkCardPresent: boolean
@@ -538,14 +542,14 @@ class AppRoot extends React.Component<Props, State> {
               hasAccessibleControllerAttached:
                 changeType === 0 /* ChangeType.Add */,
             })
+          } else if (isCardReader(device)) {
+            this.setState({
+              hasCardReaderAttached: changeType === 0 /* ChangeType.Add */,
+            })
           } else {
-            const [printer, cardReader] = await Promise.all([
-              hardware.readPrinterStatus(),
-              hardware.readCardReaderStatus(),
-            ])
+            const printer = await hardware.readPrinterStatus()
             this.setState({
               hasPrinterAttached: printer.connected,
-              hasCardReaderAttached: cardReader.connected,
             })
           }
         }

--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -1,4 +1,3 @@
-import fetchMock from 'fetch-mock'
 import fakeKiosk, {
   fakeDevice,
   fakePrinterInfo,
@@ -50,14 +49,6 @@ describe('KioskHardware', () => {
     ])
 
     expect(await hardware.readPrinterStatus()).toEqual({ connected: false })
-  })
-
-  it('gets card reader status by checking /card/reader', async () => {
-    const kiosk = fakeKiosk()
-    const hardware = new KioskHardware(kiosk)
-
-    fetchMock.get('/card/reader', () => JSON.stringify({ connected: true }))
-    expect(await hardware.readCardReaderStatus()).toEqual({ connected: true })
   })
 })
 

--- a/src/utils/Hardware.ts
+++ b/src/utils/Hardware.ts
@@ -8,11 +8,6 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'kiosk-browser'
 
-import fetchJSON from './fetchJSON'
-
-interface CardReaderStatus {
-  connected: boolean
-}
 interface PrinterStatus {
   connected: boolean
 }
@@ -33,16 +28,16 @@ export function isAccessibleController(device: Device): boolean {
   )
 }
 
-export const OmniKeyCardReaderVendorId = 0x076b
-export const OmniKeyCardReaderProductId = 0x3031
+export const OmniKeyCardReaderDeviceName = 'OMNIKEY_3x21_Smart_Card_Reader'
+export const OmniKeyCardReaderManufacturer = 'HID_Global'
 
 /**
  * Determines whether a device is the card reader.
  */
 export function isCardReader(device: Device): boolean {
   return (
-    device.vendorId === OmniKeyCardReaderVendorId &&
-    device.productId === OmniKeyCardReaderProductId
+    device.manufacturer === OmniKeyCardReaderManufacturer &&
+    device.deviceName === OmniKeyCardReaderDeviceName
   )
 }
 
@@ -64,11 +59,6 @@ export interface Hardware {
    * Reads Battery status
    */
   readBatteryStatus(): Promise<BatteryInfo>
-
-  /**
-   * Reads Card Reader status
-   */
-  readCardReaderStatus(): Promise<CardReaderStatus>
 
   /**
    * Reads Printer status
@@ -113,11 +103,11 @@ export class MemoryHardware implements Hardware {
 
   private cardReader: Readonly<Device> = {
     deviceAddress: 0,
-    deviceName: 'OMNIKEY_3x21_Smart_Card_Reader',
+    deviceName: OmniKeyCardReaderDeviceName,
     locationId: 0,
-    manufacturer: 'HID_Global',
-    productId: OmniKeyCardReaderProductId,
-    vendorId: OmniKeyCardReaderVendorId,
+    manufacturer: OmniKeyCardReaderManufacturer,
+    vendorId: 0x076b,
+    productId: 0x3031,
     serialNumber: '',
   }
 
@@ -176,15 +166,6 @@ export class MemoryHardware implements Hardware {
     this.batteryStatus = {
       ...this.batteryStatus,
       level,
-    }
-  }
-
-  /**
-   * Reads Card Reader status
-   */
-  public async readCardReaderStatus(): Promise<CardReaderStatus> {
-    return {
-      connected: Array.from(this.devices).some(isCardReader),
     }
   }
 
@@ -320,13 +301,6 @@ export class KioskHardware extends MemoryHardware {
    */
   public async readBatteryStatus(): Promise<BatteryInfo> {
     return this.kiosk.getBatteryInfo()
-  }
-
-  /**
-   * Reads Card Reader status
-   */
-  public async readCardReaderStatus(): Promise<CardReaderStatus> {
-    return await fetchJSON<CardReaderStatus>('/card/reader')
   }
 
   /**


### PR DESCRIPTION
Previously, we were checking `/card/reader` on USB events that didn't match a known device (which was just the accessible controller). With this change, we now look for the card reader too but by device & manufacturer name rather than vendor ID and product ID. @benadida was concerned that those values might not be stable for all the devices we have, but that the string names would be.

Avoiding `/card/reader` has the benefit of avoiding a race condition that rarely happened in development but seems to always happen on the real hardware. BMD would receive a USB event and request `/card/reader` before `module-smartcards` ever noticed the card reader was connected, so the request would return `{ connected: false }`. This caused a persistent "Card Reader Not Detected" screen. With this fix it should appear only when the card reader is actually absent.