### PR TITLE
fix: do not show "no card reader" screen unless needed

### DIFF
--- a/src/utils/Hardware.test.ts
+++ b/src/utils/Hardware.test.ts
@@ -2,7 +2,16 @@ import fakeKiosk, {
   fakeDevice,
   fakePrinterInfo,
 } from '../../test/helpers/fakeKiosk'
-import { getHardware, KioskHardware, MemoryHardware } from './Hardware'
+import {
+  getHardware,
+  KioskHardware,
+  MemoryHardware,
+  isCardReader,
+  OmniKeyCardReaderVendorId,
+  OmniKeyCardReaderProductId,
+  OmniKeyCardReaderDeviceName,
+  OmniKeyCardReaderManufacturer,
+} from './Hardware'
 
 describe('KioskHardware', () => {
   it('is used by getHardware when window.kiosk is set', () => {
@@ -190,5 +199,44 @@ describe('MemoryHardware', () => {
 
     hardware.addDevice(device)
     expect(callback).not.toHaveBeenCalled()
+  })
+})
+
+describe('isCardReader', () => {
+  it('does not match just any device', () => {
+    expect(isCardReader(fakeDevice())).toBe(false)
+  })
+
+  it('matches a device with the right vendor ID and product ID', () => {
+    expect(
+      isCardReader(
+        fakeDevice({
+          vendorId: OmniKeyCardReaderVendorId,
+          productId: OmniKeyCardReaderProductId,
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('matches a device with the right product name and manufacturer (using spaces)', () => {
+    expect(
+      isCardReader(
+        fakeDevice({
+          deviceName: OmniKeyCardReaderDeviceName,
+          manufacturer: OmniKeyCardReaderManufacturer,
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('matches a device with the right product name and manufacturer (using underscores)', () => {
+    expect(
+      isCardReader(
+        fakeDevice({
+          deviceName: OmniKeyCardReaderDeviceName.replace(/ /g, '_'),
+          manufacturer: OmniKeyCardReaderManufacturer.replace(/ /g, '_'),
+        })
+      )
+    ).toBe(true)
   })
 })

--- a/src/utils/Hardware.ts
+++ b/src/utils/Hardware.ts
@@ -28,16 +28,20 @@ export function isAccessibleController(device: Device): boolean {
   )
 }
 
-export const OmniKeyCardReaderDeviceName = 'OMNIKEY_3x21_Smart_Card_Reader'
-export const OmniKeyCardReaderManufacturer = 'HID_Global'
+export const OmniKeyCardReaderDeviceName = 'OMNIKEY 3x21 Smart Card Reader'
+export const OmniKeyCardReaderManufacturer = 'HID Global'
+export const OmniKeyCardReaderVendorId = 0x076b
+export const OmniKeyCardReaderProductId = 0x3031
 
 /**
  * Determines whether a device is the card reader.
  */
 export function isCardReader(device: Device): boolean {
   return (
-    device.manufacturer === OmniKeyCardReaderManufacturer &&
-    device.deviceName === OmniKeyCardReaderDeviceName
+    (device.manufacturer.replace(/_/g, ' ') === OmniKeyCardReaderManufacturer &&
+      device.deviceName.replace(/_/g, ' ') === OmniKeyCardReaderDeviceName) ||
+    (device.vendorId === OmniKeyCardReaderVendorId &&
+      device.productId === OmniKeyCardReaderProductId)
   )
 }
 
@@ -106,8 +110,8 @@ export class MemoryHardware implements Hardware {
     deviceName: OmniKeyCardReaderDeviceName,
     locationId: 0,
     manufacturer: OmniKeyCardReaderManufacturer,
-    vendorId: 0x076b,
-    productId: 0x3031,
+    vendorId: OmniKeyCardReaderVendorId,
+    productId: OmniKeyCardReaderProductId,
     serialNumber: '',
   }
 


### PR DESCRIPTION
I noticed that the device name and manufacturer vary on Ubuntu-on-Lenovo and Ubuntu-on-Parallels by using underscores in the former and spaces in the latter.

I also reinstated the vendor ID and product ID check as a backup, and will use a device if it matches either pair.
