### PR TITLE
simplify and fix state machine for printing

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@types/styled-components": "^4.4.2",
     "@votingworks/ballot-encoder": "^1.2.0",
     "@votingworks/qrcode.react": "^1.0.0",
-    "@xstate/react": "^0.8.1",
     "abortcontroller-polyfill": "^1.4.0",
     "base64-js": "^1.3.1",
     "fetch-mock": "^8.3.2",
@@ -103,8 +102,7 @@
     "react-scripts": "3.3.0",
     "styled-components": "^4.4.1",
     "typescript": "^3.7.5",
-    "use-interval": "^1.2.1",
-    "xstate": "^4.7.7"
+    "use-interval": "^1.2.1"
   },
   "devDependencies": {
     "@codemod/parser": "^1.0.6",

--- a/src/endToEnd.ts
+++ b/src/endToEnd.ts
@@ -12,7 +12,7 @@ export default async function encryptBallotWithElectionGuard(
       {
         method: 'post',
         body: JSON.stringify({
-          ballot: ballot,
+          ballot,
           currentBallotCount: 0,
         }),
         headers: {

--- a/src/endToEnd.ts
+++ b/src/endToEnd.ts
@@ -1,20 +1,26 @@
-import { VotesDict } from '@votingworks/ballot-encoder'
+import { CompletedBallot } from '@votingworks/ballot-encoder'
 
 import { E2EAPI } from './config/types'
 import fetchJSON from './utils/fetchJSON'
 
-export default async function encryptBallot(
-  // eslint-disable-next-line
-  votes: VotesDict
+export default async function encryptBallotWithElectionGuard(
+  ballot: CompletedBallot
 ) {
   try {
     const { tracker } = await fetchJSON<E2EAPI>(
       '/electionguard/EncryptBallot',
       {
         method: 'post',
-        body: JSON.stringify(votes),
+        body: JSON.stringify({
+          ballot: ballot,
+          currentBallotCount: 0,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       }
     )
+
     return tracker
   } catch (error) {
     return ''

--- a/src/pages/PrintOnlyScreen.tsx
+++ b/src/pages/PrintOnlyScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import { VotesDict, Election } from '@votingworks/ballot-encoder'
+import { VotesDict, Election, BallotType } from '@votingworks/ballot-encoder'
 
 import Loading from '../components/Loading'
 import ElectionGuardBallotTrackingCode from '../components/ElectionGuardBallotTrackingCode'
@@ -14,6 +14,7 @@ import { MarkVoterCardFunction, PartialUserSettings } from '../config/types'
 import { Printer } from '../utils/printer'
 import isEmptyObject from '../utils/isEmptyObject'
 import { randomBase64 } from '../utils/random'
+import { getBallotStyle, getPrecinctById } from '../utils/election'
 
 import encryptBallotWithElectionGuard from '../endToEnd'
 
@@ -75,7 +76,16 @@ const PrintOnlyScreen = ({
   }
 
   const generateTrackingCode = async () => {
-    const ballotTrackingCode = await encryptBallotWithElectionGuard(votes)
+    const ballotTrackingCode = await encryptBallotWithElectionGuard({
+      election,
+      ballotStyle: getBallotStyle({ ballotStyleId, election }),
+      precinct: getPrecinctById({ precinctId, election })!,
+      ballotId,
+      votes,
+      isTestBallot: !isLiveMode,
+      ballotType: BallotType.Standard,
+    })
+
     // TODO: handle failure to get ballot tracking code
     setTrackerString(ballotTrackingCode)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,11 +2226,6 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@xstate/react@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-0.8.1.tgz#df200547cca24c909572b7aef1ddab8bca3a0603"
-  integrity sha512-8voZm4GX3x70lNQVvoGedoObPYapkQIbgMhE+xOQEsm8Ait4Zto6R01SZ6WJD4qvLl8JPV6uq96OcFRdEsVESg==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -13756,11 +13751,6 @@ xmlchars@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-1.3.1.tgz#1dda035f833dbb4f86a0c28eaa6ca769214793cf"
   integrity sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==
-
-xstate@^4.7.7:
-  version "4.7.7"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.7.7.tgz#3533edec1f8d72f147009301f071dc35f1a5ac33"
-  integrity sha512-ctV7gShkDe+HOLP1MV78FRqWhNtmMJvtGjlgP10N6MeELVxGbvc54WrwfBv0e/xyjSaqveM48Pohut71naqVNA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
The previous implementation had an issue where the ballot id was being set and then, without a render cycle, the encryption was being done, which caused the ballot ID that was sent to the encryption to be the *old* ballot ID, starting with the empty string for the first one.

In trying to fix this, I realized that the state machine we need here is so simple that using the full-blown state machine package seems like significant overkill. So I tried the following simple-string-state-and-useEffect implementation, which seems to work like a charm.