### PR TITLE
delete eg encrypted ballots on tally reset

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -72,6 +72,8 @@ import {
   isCardReader,
 } from './utils/Hardware'
 
+import { deleteElectionGuardBallots } from './endToEnd'
+
 interface CardState {
   isClerkCardPresent: boolean
   isPollWorkerCardPresent: boolean
@@ -830,6 +832,9 @@ class AppRoot extends React.Component<Props, State> {
   }
 
   public resetTally = () => {
+    // reset electionguard ballots
+    deleteElectionGuardBallots()
+
     this.setState(
       ({ election }) => ({
         ballotsPrintedCount: this.initialState.ballotsPrintedCount,

--- a/src/endToEnd.ts
+++ b/src/endToEnd.ts
@@ -26,3 +26,25 @@ export default async function encryptBallotWithElectionGuard(
     return ''
   }
 }
+
+export async function deleteElectionGuardBallots() {
+  try {
+    const now = new Date()
+    const filename =
+      'encrypted-ballots_' +
+      now.getFullYear() +
+      '_' +
+      (now.getMonth() + 1) +
+      '_' +
+      now.getDate()
+
+    fetch('/electionguard/BallotFile?fileName=' + filename, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+  } catch (error) {
+    return
+  }
+}


### PR DESCRIPTION
On tally reset, we inform the EG backend that encrypted ballots for the current day should be deleted. The reason it's the current day is that is the limitation of the EG API for now -- it removes one file of votes for that day. In a typical election setting, that should do the trick, though there are some gotchas we'll want to review with the EG team and get a better API that includes test/live mode.