### PR TITLE
fix: only enable screen reader with accessible controller

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { BrowserRouter, Route } from 'react-router-dom'
 
 import 'normalize.css'
@@ -14,7 +14,7 @@ import { WebServiceCard } from './utils/Card'
 import { LocalStorage } from './utils/Storage'
 import { getUSEnglishVoice } from './utils/voices'
 import getPrinter from './utils/printer'
-import { getHardware } from './utils/Hardware'
+import { getHardware, isAccessibleController } from './utils/Hardware'
 
 import AppRoot, { Props as AppRootProps, AppStorage } from './AppRoot'
 import FocusManager from './components/FocusManager'
@@ -43,6 +43,19 @@ const App = ({
   hardware = getHardware(),
   machineId = machineIdProvider,
 }: Props) => {
+  screenReader.mute()
+
+  /* istanbul ignore next - need to figure out how to test this */
+  useEffect(() => {
+    const listener = hardware.onDeviceChange.add((changeType, device) => {
+      if (isAccessibleController(device)) {
+        screenReader.toggleMuted(changeType === 1 /* ChangeType.Remove */)
+      }
+    })
+
+    return () => listener.remove()
+  }, [hardware, screenReader])
+
   /* istanbul ignore next - need to figure out how to test this */
   const onKeyPress = useCallback(
     (event: React.KeyboardEvent) => {

--- a/src/SampleApp.tsx
+++ b/src/SampleApp.tsx
@@ -61,7 +61,7 @@ const SampleApp = ({
   card = getSampleCard(),
   storage = getSampleStorage(),
   machineId = getSampleMachineId(),
-  hardware = MemoryHardware.standard,
+  hardware = MemoryHardware.demo,
   ...rest
 }: Props) => (
   <App

--- a/src/utils/Hardware.ts
+++ b/src/utils/Hardware.ts
@@ -137,6 +137,14 @@ export class MemoryHardware implements Hardware {
     })
   }
 
+  public static get demo(): MemoryHardware {
+    return new MemoryHardware({
+      connectPrinter: true,
+      connectAccessibleController: false,
+      connectCardReader: true,
+    })
+  }
+
   /**
    * Sets Accessible Controller connected
    */
@@ -322,4 +330,8 @@ export class KioskHardware extends MemoryHardware {
  * Get Hardware based upon environment.
  */
 export const getHardware = () =>
-  window.kiosk ? new KioskHardware(window.kiosk) : MemoryHardware.standard
+  window.kiosk
+    ? // Running in kiosk-browser, so use that to access real hardware.
+      new KioskHardware(window.kiosk)
+    : // Running in normal browser, so emulate hardware.
+      MemoryHardware.demo

--- a/test/helpers/fakeTTS.ts
+++ b/test/helpers/fakeTTS.ts
@@ -4,7 +4,7 @@ import { TextToSpeech } from '../../src/utils/ScreenReader'
  * Builds a fake `TextToSpeech` instance with mock functions.
  */
 export default function fakeTTS(): jest.Mocked<TextToSpeech> {
-  let isMuted = false
+  let isMuted = true
 
   return {
     speak: jest.fn().mockResolvedValue(undefined),
@@ -16,5 +16,8 @@ export default function fakeTTS(): jest.Mocked<TextToSpeech> {
       isMuted = false
     }),
     isMuted: jest.fn(() => isMuted),
+    toggleMuted: jest.fn((muted = !isMuted) => {
+      isMuted = muted
+    }),
   }
 }


### PR DESCRIPTION
It turns out that `SpeechSynthesisUtterance#volume` is a lie in Chromium on Linux with our setup. Setting it to 0 does nothing, and speech is still played through the speakers. So instead of trying to play nice we'll just selectively call `speechSynthesis.speak(…)` when we're not muted.