### PR TITLE
extend timeout

### DIFF
--- a/src/pages/PrintOnlyScreen.tsx
+++ b/src/pages/PrintOnlyScreen.tsx
@@ -63,7 +63,7 @@ interface Props {
 }
 
 export const printingMessageTimeoutSeconds = 4
-export const ballotTrackingCodeTimeoutSeconds = 7
+export const ballotTrackingCodeTimeoutSeconds = 20
 
 const PrintOnlyScreen = ({
   ballotStyleId,


### PR DESCRIPTION
On tablet, encryption takes 10-11s. So let's give ourselves plenty of time.