### PR TITLE
Display warning on VxPring when no power.

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -1013,6 +1013,7 @@ class AppRoot extends React.Component<Props, State> {
             precinctId={precinctId}
             printer={this.props.printer}
             setUserSettings={this.setUserSettings}
+            showNoChargerAttachedWarning={!hasChargerAttached}
             updateTally={this.updateTally}
             votes={votes}
           />

--- a/src/pages/PrintOnlyScreen.tsx
+++ b/src/pages/PrintOnlyScreen.tsx
@@ -41,6 +41,7 @@ interface Props {
   precinctId: string
   printer: Printer
   setUserSettings: (partial: PartialUserSettings) => void
+  showNoChargerAttachedWarning: boolean
   updateTally: () => void
   votes: VotesDict
 }
@@ -57,6 +58,7 @@ const PrintOnlyScreen = ({
   precinctId,
   printer,
   setUserSettings,
+  showNoChargerAttachedWarning,
   updateTally,
   votes,
 }: Props) => {
@@ -165,7 +167,18 @@ const PrintOnlyScreen = ({
           />
         </p>
         <h1>Insert Card</h1>
-        <p>Insert Card to print your official ballot.</p>
+        <p>
+          Insert Card to print your official ballot.
+          {showNoChargerAttachedWarning && (
+            <React.Fragment>
+              <br />
+              <Text as="span" warning small>
+                <strong>No Power Detected.</strong> Please ask a poll worker to
+                plug in the power cord for this machine.
+              </Text>
+            </React.Fragment>
+          )}
+        </p>
       </React.Fragment>
     )
   }


### PR DESCRIPTION
Fixes #1193 

Same text as used when power is disconnected on VxMark.

![image](https://user-images.githubusercontent.com/28444/73790528-7a6d5800-4755-11ea-9192-31027acb993c.png)
