### PR TITLE
fix: maybe address freezing issue

### DIFF
--- a/src/AppQuitOnIdle.test.tsx
+++ b/src/AppQuitOnIdle.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { render } from '@testing-library/react'
+
+import App from './App'
+
+import { advanceTimersAndPromises } from '../test/helpers/smartcards'
+
+import {
+  setElectionInStorage,
+  setStateInStorage,
+} from '../test/helpers/election'
+
+import { MemoryStorage } from './utils/Storage'
+import { AppStorage } from './AppRoot'
+import { MemoryCard } from './utils/Card'
+import { MemoryHardware } from './utils/Hardware'
+import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
+import fakeKiosk from '../test/helpers/fakeKiosk'
+import { QUIT_KIOSK_IDLE_SECONDS } from './config/globals'
+
+jest.useFakeTimers()
+
+beforeEach(() => {
+  window.location.href = '/'
+  window.kiosk = fakeKiosk()
+})
+
+afterEach(() => {
+  window.kiosk = undefined
+})
+
+test('Insert Card screen idle timeout to quit app', async () => {
+  const card = new MemoryCard()
+  const hardware = MemoryHardware.standard
+  const storage = new MemoryStorage<AppStorage>()
+  const machineConfig = fakeMachineConfigProvider({
+    // machineId determines whether we quit on idle or not
+    machineId: '0001',
+  })
+
+  setElectionInStorage(storage)
+  setStateInStorage(storage)
+
+  const { getByText } = render(
+    <App
+      card={card}
+      hardware={hardware}
+      storage={storage}
+      machineConfig={machineConfig}
+    />
+  )
+
+  await advanceTimersAndPromises()
+
+  // Ensure we're on the Insert Card screen
+  getByText('Insert voter card to load ballot.')
+  expect(window.kiosk?.quit).not.toHaveBeenCalled()
+
+  // Check that we requested a quit after the idle timer fired.
+  await advanceTimersAndPromises(QUIT_KIOSK_IDLE_SECONDS)
+  expect(window.kiosk?.quit).toHaveBeenCalledTimes(1)
+})

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -19,6 +19,7 @@ import { RouteComponentProps } from 'react-router-dom'
 // eslint-disable-next-line import/no-unresolved
 import { Listener, ChangeType, Device } from 'kiosk-browser'
 import './App.css'
+import IdleTimer from 'react-idle-timer'
 import Ballot from './components/Ballot'
 import * as GLOBALS from './config/globals'
 import {
@@ -1030,7 +1031,9 @@ class AppRoot extends React.Component<Props, State> {
           )
         }
       }
-      return (
+
+      const shouldQuitOnIdle = !machineConfig.machineId.endsWith('0')
+      const insertCardScreen = (
         <InsertCardScreen
           appPrecinctId={appPrecinctId}
           election={election}
@@ -1041,6 +1044,17 @@ class AppRoot extends React.Component<Props, State> {
           isLiveMode={isLiveMode}
           isPollsOpen={isPollsOpen}
         />
+      )
+
+      return shouldQuitOnIdle ? (
+        <IdleTimer
+          onIdle={() => window.kiosk?.quit()}
+          timeout={GLOBALS.QUIT_KIOSK_IDLE_SECONDS * 1000}
+        >
+          {insertCardScreen}
+        </IdleTimer>
+      ) : (
+        insertCardScreen
       )
     } else {
       return <UnconfiguredScreen />

--- a/src/config/globals.ts
+++ b/src/config/globals.ts
@@ -17,3 +17,4 @@ export enum YES_NO_VOTES {
 }
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40
 export const LOW_BATTERY_THRESHOLD = 0.25
+export const QUIT_KIOSK_IDLE_SECONDS = 5 * 60 // 5 minutes

--- a/src/types/kiosk-browser.d.ts
+++ b/src/types/kiosk-browser.d.ts
@@ -57,6 +57,7 @@ declare module 'kiosk-browser' {
     getBatteryInfo(): Promise<BatteryInfo>
     getDeviceList(): Promise<Device[]>
     onDeviceChange: Listeners<[ChangeType, Device]>
+    quit(): void
   }
 }
 

--- a/test/helpers/fakeKiosk.ts
+++ b/test/helpers/fakeKiosk.ts
@@ -52,5 +52,6 @@ export default function fakeKiosk({
       remove: jest.fn(),
       trigger: jest.fn(),
     },
+    quit: jest.fn(),
   }
 }


### PR DESCRIPTION
This causes VxMark to quit after being idle on the "Insert Card" screen for 5 minutes. This MUST be paired with some sort of respawn functionality. It will only quit if the machine ID does _not_ end in "0", so with machine IDs using sequential integers this means ~90% of machines will have this restart behavior and  ~10% will not.