### PR TITLE
Print polls report on colored paper

### DIFF
--- a/src/pages/PollWorkerScreen.tsx
+++ b/src/pages/PollWorkerScreen.tsx
@@ -66,7 +66,7 @@ const PollWorkerScreen = ({
     let isPrinting = false
     async function printReport() {
       if (!isPrinting && isPrintingReport) {
-        await printer.print()
+        await printer.print('', 'Tray2')
         window.setTimeout(() => {
           togglePollsOpen()
           setIsPrintingReport(false)


### PR DESCRIPTION
because the ballot paper has endorsements on the back.

Fixes #1200 