### PR TITLE
Disable "add write-in candidate" button instead of removing it.

### DIFF
--- a/src/AppContestWriteIn.test.tsx
+++ b/src/AppContestWriteIn.test.tsx
@@ -94,7 +94,6 @@ it('Single Seat Contest with Write In', async () => {
   advanceTimers()
 
   // Remove Write-In Candidate
-  // await wait(() => getByText('BOB'))
   fireEvent.click(getByText('BOB').closest('button')!)
   fireEvent.click(getByText('Yes, Remove.'))
   advanceTimers()
@@ -107,7 +106,7 @@ it('Single Seat Contest with Write In', async () => {
   fireEvent.click(getByText('Accept'))
   expect(getByText('SAL').closest('button')!.dataset.selected).toBe('true')
 
-  // Try to Select Other Candidate when Max Candidates Selected.
+  // Try to Select Other Candidate when max candidates are selected.
   fireEvent.click(
     getByText(singleSeatContestWithWriteIn.candidates[0].name).closest(
       'button'
@@ -117,7 +116,13 @@ it('Single Seat Contest with Write In', async () => {
     `You may only select ${singleSeatContestWithWriteIn.seats} candidate in this contest. To vote for ${singleSeatContestWithWriteIn.candidates[0].name}, you must first unselect the selected candidate.`
   )
   fireEvent.click(getByText('Okay'))
-  advanceTimers() // For 200ms Delay in closing modal
+
+  // Try to add another write-in when max candidates are selected.
+  fireEvent.click(getByText('add write-in candidate').closest('button')!)
+  getByText(
+    `You may only select ${singleSeatContestWithWriteIn.seats} candidate in this contest. To vote for a write-in candidate, you must first unselect the selected candidate.`
+  )
+  fireEvent.click(getByText('Okay'))
 
   // Go to review page and confirm write in exists
   while (!queryByText('Review Your Votes')) {

--- a/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -974,6 +974,25 @@ exports[`Single Seat Contest 1`] = `
                   </p>
                 </div>
               </button>
+              <button
+                class="c13"
+                data-choice="write-in"
+                data-selected="false"
+                role="option"
+                type="button"
+              >
+                <div
+                  class="c4"
+                >
+                  <p
+                    aria-label="add write-in candidate."
+                  >
+                    <em>
+                      add write-in candidate
+                    </em>
+                  </p>
+                </div>
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -397,6 +397,13 @@ class CandidateContest extends React.Component<Props, State> {
     scrollContainer.scrollTo({ behavior: 'smooth', left: 0, top })
   }
 
+  public handleDisabledAddWriteInClick = () => {
+    this.handleChangeVoteAlert({
+      id: 'write-in',
+      name: 'a write-in candidate',
+    } as Candidate)
+  }
+
   public static contextType = BallotContext
 
   public render() {
@@ -512,11 +519,15 @@ class CandidateContest extends React.Component<Props, State> {
                           </ChoiceButton>
                         )
                       })}
-                  {contest.allowWriteIns && !hasReachedMaxSelections && (
+                  {contest.allowWriteIns && (
                     <ChoiceButton
                       choice="write-in"
                       isSelected={false}
-                      onPress={this.initWriteInCandidate}
+                      onPress={
+                        hasReachedMaxSelections
+                          ? this.handleDisabledAddWriteInClick
+                          : this.initWriteInCandidate
+                      }
                     >
                       <Prose>
                         <p aria-label="add write-in candidate.">

--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -456,10 +456,7 @@ class CandidateContest extends React.Component<Props, State> {
                     )
                     const isDisabled = hasReachedMaxSelections && !isChecked
                     const handleDisabledClick = () => {
-                      /* istanbul ignore else */
-                      if (isDisabled) {
-                        this.handleChangeVoteAlert(candidate)
-                      }
+                      this.handleChangeVoteAlert(candidate)
                     }
                     const party =
                       candidate.partyId &&


### PR DESCRIPTION
On candidate contests, the button to "add write-in candidate" now works the same as button to add a named candidate.

Resolves #1034
Related to #369 

Note: Pls ignore typo in branch name. 😝 But because of it… double-check this PR!

Also, this change is gonna make @mcchilders happy.