### PR TITLE
fix: speak text to confirm write-in removal

### DIFF
--- a/src/components/CandidateContest.tsx
+++ b/src/components/CandidateContest.tsx
@@ -599,7 +599,7 @@ class CandidateContest extends React.Component<Props, State> {
           centerContent
           content={
             <Prose>
-              <Text>
+              <Text id="modalaudiofocus">
                 Do you want to unselect and remove{' '}
                 {candidatePendingRemoval?.name}?
               </Text>


### PR DESCRIPTION
Without this, it reads "Alert Modal", which is the default value for the ARIA label of a `Modal`. Now, it reads "Do you want to unselect and remove [write-in name]?"
