### PR TITLE
fix: print test ballot decks with kiosk printing when available

### DIFF
--- a/src/pages/TestBallotDeckScreen.tsx
+++ b/src/pages/TestBallotDeckScreen.tsx
@@ -139,7 +139,7 @@ const TestBallotDeckScreen = ({
                   for {precinct.name}.
                 </p>
                 <p>
-                  <Button big primary onPress={window.print}>
+                  <Button big primary onPress={(window.kiosk ?? window).print}>
                     Print {ballots.length} ballots
                   </Button>
                 </p>


### PR DESCRIPTION
This should probably come through the `ballotContext` rather than directly reaching for `kiosk.print`, but we need this quickly.
