### PR TITLE
build(vscode): use the workspace-installed TypeScript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,6 @@
       "name": "BMD Web",
       "remotePort": 3000
     }
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
This makes sure that the errors from `tsc` and the errors in VS Code are consistent.