### PR TITLE
refactor: introduce `globalThis`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
     // fetch: true, // required if using via 'jest-fetch-mock'
     fetchMock: true, // required if using via 'jest-fetch-mock'
+    globalThis: true,
   },
   parserOptions: {
     ecmaFeatures: {

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -6,33 +6,30 @@ import fetchMock from 'fetch-mock'
 import { TextDecoder, TextEncoder } from 'util'
 import { mockOf } from '../test/testUtils'
 
-// window.crypto is not defined in JSDOM
-// TODO: consider https://github.com/jsdom/jsdom/issues/1612#issuecomment-454040272
-Object.defineProperty(global, 'crypto', {
+// globalThis.crypto is not defined in JSDOM
+Object.defineProperty(globalThis, 'crypto', {
   value: {
-    getRandomValues: (arr: number[]) => crypto.randomBytes(arr.length),
+    getRandomValues(arr: Parameters<typeof crypto['randomFillSync']>[0]) {
+      return crypto.randomFillSync(arr)
+    },
   },
 })
 
 // react-gamepad calls this function which does not exist in JSDOM
-window.navigator.getGamepads = jest.fn(() => [])
+globalThis.navigator.getGamepads = jest.fn(() => [])
 
-window.print = jest.fn(() => {
-  throw new Error('window.print() should never be called')
+globalThis.print = jest.fn(() => {
+  throw new Error('globalThis.print() should never be called')
 })
 
-const printMock = mockOf(window.print)
+const printMock = mockOf(globalThis.print)
 
 function mockSpeechSynthesis() {
-  const w = window as {
-    speechSynthesis: typeof speechSynthesis
-    SpeechSynthesisUtterance: typeof SpeechSynthesisUtterance
-    SpeechSynthesisEvent: typeof SpeechSynthesisEvent
-  }
-
-  w.speechSynthesis = makeSpeechSynthesisDouble()
-  w.SpeechSynthesisUtterance = jest.fn().mockImplementation(text => ({ text }))
-  w.SpeechSynthesisEvent = jest.fn()
+  globalThis.speechSynthesis = makeSpeechSynthesisDouble()
+  globalThis.SpeechSynthesisUtterance = jest
+    .fn()
+    .mockImplementation(text => ({ text }))
+  globalThis.SpeechSynthesisEvent = jest.fn()
 }
 
 function makeSpeechSynthesisDouble(): typeof speechSynthesis {
@@ -64,7 +61,5 @@ afterEach(() => {
   printMock.mockClear()
 })
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-;(global as any).TextDecoder = TextDecoder
-;(global as any).TextEncoder = TextEncoder
-/* eslint-enable @typescript-eslint/no-explicit-any */
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder


### PR DESCRIPTION
`globalThis` was introduced a while back to solve the "how do I reference the global object?" problem. It's implemented in Chrome, Safari, Node.js, Firefox, etc. I'm adding it only to the `setupTests.tsx` file for now because `globalThis` is _not_ currently supported in the default browser for Windows 10, the legacy version of Microsoft Edge (i.e. not the new version based on Chrome). If we care about supporting legacy Microsoft Edge, we can easily add a polyfill.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
