### PR TITLE
fix muting logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,9 @@ const App = ({
   /* istanbul ignore next - need to figure out how to test this */
   useEffect(() => {
     const subscription = hardware.devices.subscribe((devices) =>
-      screenReader.toggleMuted(Array.from(devices).some(isAccessibleController))
+      screenReader.toggleMuted(
+        !Array.from(devices).some(isAccessibleController)
+      )
     )
 
     return () => subscription.unsubscribe()


### PR DESCRIPTION
As best as I can tell, we've had it backwards for a while. We were muting when an accessible controller was plugged in.