### PR TITLE
don't send extra args to kiosk.print for test deck

### DIFF
--- a/src/pages/TestBallotDeckScreen.test.tsx
+++ b/src/pages/TestBallotDeckScreen.test.tsx
@@ -11,6 +11,8 @@ import { mockOf, render } from '../../test/testUtils'
 import { randomBase64 } from '../utils/random'
 import TestBallotDeckScreen from './TestBallotDeckScreen'
 
+import fakeKiosk from '../../test/helpers/fakeKiosk'
+
 // mock the random value so the snapshots match
 jest.mock('../utils/random')
 const randomBase64Mock = mockOf(randomBase64)
@@ -33,4 +35,20 @@ it('renders test decks appropriately', () => {
   expect(getAllByText('For either', { exact: false })).toHaveLength(31)
   expect(getAllByText('FOR Measure 420A', { exact: false })).toHaveLength(31)
   expect(getAllByText('County Commissioners')).toHaveLength(52)
+
+  const oldWindowPrint = window.print
+  delete window.print
+  window.print = jest.fn()
+
+  fireEvent.click(getByText('Print 63 ballots'))
+
+  expect(window.print).toHaveBeenCalled()
+
+  window.print = oldWindowPrint
+
+  window.kiosk = fakeKiosk()
+
+  fireEvent.click(getByText('Print 63 ballots'))
+
+  expect(window.kiosk!.print).toHaveBeenCalledWith()
 })

--- a/src/pages/TestBallotDeckScreen.tsx
+++ b/src/pages/TestBallotDeckScreen.tsx
@@ -151,7 +151,13 @@ const TestBallotDeckScreen = ({
                   for {precinct.name}.
                 </p>
                 <p>
-                  <Button big primary onPress={(window.kiosk ?? window).print}>
+                  <Button
+                    big
+                    primary
+                    onPress={() => {
+                      ;(window.kiosk ?? window).print()
+                    }}
+                  >
                     Print {ballots.length} ballots
                   </Button>
                 </p>


### PR DESCRIPTION
doing so appears to crash kiosk, likely because we're sending an event and it's expecting an options object.

we should fix kiosk at some point, but simplest fix right now is to not send anything to `kiosk.print()` unless we mean to.