### PR TITLE
restarting on idle is a good idea for all machines.

### DIFF
--- a/src/AppQuitOnIdle.test.tsx
+++ b/src/AppQuitOnIdle.test.tsx
@@ -34,8 +34,9 @@ test('Insert Card screen idle timeout to quit app', async () => {
   const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineConfig = fakeMachineConfigProvider({
-    // machineId determines whether we quit on idle or not
-    machineId: '0001',
+    // machineId used to determine whether we quit. Now they all do.
+    // making sure a machineId that ends in 0 still triggers.
+    machineId: '0000',
   })
 
   setElectionInStorage(storage)

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -1045,7 +1045,6 @@ class AppRoot extends React.Component<Props, State> {
         }
       }
 
-      const shouldQuitOnIdle = !machineConfig.machineId.endsWith('0')
       const insertCardScreen = (
         <InsertCardScreen
           appPrecinctId={appPrecinctId}
@@ -1059,15 +1058,13 @@ class AppRoot extends React.Component<Props, State> {
         />
       )
 
-      return shouldQuitOnIdle ? (
+      return (
         <IdleTimer
           onIdle={() => window.kiosk?.quit()}
           timeout={GLOBALS.QUIT_KIOSK_IDLE_SECONDS * 1000}
         >
           {insertCardScreen}
         </IdleTimer>
-      ) : (
-        insertCardScreen
       )
     } else {
       return <UnconfiguredScreen />


### PR DESCRIPTION
We used to not idle-restart machines that have a trailing `0` in their machine ID, as an experiment. This was a good idea, but we didn't really follow through on the experiment, and we want to be extra sure that our restart precaution is happening everywhere, it's a good idea for lots of reasons (clearing out Chrome memory, etc.)