### PR TITLE
default card reader presence to true

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -177,7 +177,7 @@ class AppRoot extends React.Component<Props, State> {
 
   private initialHardwareState: HardwareState = {
     hasAccessibleControllerAttached: false,
-    hasCardReaderAttached: false,
+    hasCardReaderAttached: true,
     hasChargerAttached: true,
     hasLowBattery: false,
     hasPrinterAttached: true,


### PR DESCRIPTION
Otherwise, on startup (and restart of kiosk-browser after 5min idle), a spurious "card reader not detected" message shows up for a few seconds -- especially because hardware detection is slower for some yet-to-be-determined reason in our prod setup.
