### PR TITLE
don't print if the precinct ID doesn't match

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -992,6 +992,11 @@ class AppRoot extends React.Component<Props, State> {
         return <ExpiredCardScreen setUserSettings={this.setUserSettings} />
       }
       if (isPollsOpen && appMode.isVxPrint && !appMode.isVxMark) {
+        if (isVoterCardPresent && precinctId) {
+          if (appPrecinctId !== precinctId) {
+            return <WrongPrecinctScreen />
+          }
+        }
         return (
           <PrintOnlyScreen
             ballotStyleId={ballotStyleId}


### PR DESCRIPTION
Don't let VxPrint print ballots for a precinct other than the one it's configured for.

[still needs tests]